### PR TITLE
Refactor SEO: centralize metadata, add new pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,14 +12,10 @@ export const metadata: Metadata = {
   title: "iny.one – Shorten URLs, Track Smarter",
   description:
     "iny.one is a free URL shortener with UTM tracking. Create short links and measure your marketing results.",
-  alternates: {
-    canonical: "https://iny.one",
-    languages: {
-      en: "https://iny.one",
-      es: "https://iny.one",
-      "x-default": "https://iny.one",
-    },
-  },
+  // Nota: canonical + hreflang se definen por página vía buildAlternates()
+  // (src/lib/seo/metadata.ts). Un canonical global aquí aplicaría la home
+  // como canonical de páginas que no declaren el suyo, y el hreflang en/es
+  // sobre la misma URL era inválido para Google.
   verification: {
     google: "WNueup03P4lmVxxos0qDu1zwMrCeEpuS4FVUuS0XHtM",
   },

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { Link as LinkIcon } from "lucide-react";
+import { ROUTES } from "@/lib/routes";
+
+/**
+ * 404 global del App Router.
+ *
+ * El resolver de enlaces cortos ([short]/route.tsx) ya renderiza su propio 404
+ * para slugs de un segmento, pero rutas como /foo/bar caían al 404 genérico de
+ * Next sin marca ni enlaces internos. Esta página devuelve status 404 (Next lo
+ * hace automáticamente) y recupera al visitante hacia las páginas principales.
+ */
+export default async function NotFound() {
+  const t = await getTranslations("404");
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 text-center">
+      <div className="bg-white rounded-2xl shadow-md p-8 max-w-md w-full">
+        <div className="flex items-center justify-center mb-4">
+          <LinkIcon className="h-8 w-8 text-indigo-600" aria-hidden="true" />
+        </div>
+        <h1 className="text-5xl font-bold text-gray-800 mb-2">{t("title")}</h1>
+        <p className="text-gray-600 mb-6">{t("subtitle")}</p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Link
+            prefetch={false}
+            href={ROUTES.HOME}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold px-4 py-2 rounded-lg transition-colors"
+          >
+            {t("goHome")}
+          </Link>
+          <Link
+            prefetch={false}
+            href={ROUTES.DASHBOARD}
+            className="bg-indigo-50 hover:bg-indigo-100 text-indigo-700 font-semibold px-4 py-2 rounded-lg transition-colors"
+          >
+            {t("goDashboard")}
+          </Link>
+        </div>
+        <p className="text-xs text-gray-400 mt-6">
+          <Link prefetch={false} href={ROUTES.HOME} className="text-indigo-600 hover:text-indigo-800 font-medium">
+            iny.one
+          </Link>{" "}
+          · {t("footer")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,43 +2,55 @@ import { type MetadataRoute } from 'next';
 
 const BASE_URL = 'https://iny.one';
 
+const enUrl = (path: string) => (path === '/' ? BASE_URL : `${BASE_URL}${path}`);
+const esUrl = (path: string) => (path === '/' ? `${BASE_URL}/es` : `${BASE_URL}/es${path}`);
+
+type ChangeFrequency = MetadataRoute.Sitemap[number]['changeFrequency'];
+
+interface BilingualEntry {
+  path: string;
+  /**
+   * Fecha literal por ruta: actualizar SOLO cuando el contenido de la página
+   * cambie de verdad. (Antes se usaba `new Date()` en cada build, lo que
+   * marcaba todas las URLs como "modificadas hoy" y degrada la señal lastmod.)
+   */
+  lastModified: string;
+  changeFrequency: ChangeFrequency;
+  priority: number;
+}
+
+const BILINGUAL_PAGES: BilingualEntry[] = [
+  { path: '/', lastModified: '2026-07-21', changeFrequency: 'weekly', priority: 1.0 },
+  { path: '/utm-builder', lastModified: '2026-07-21', changeFrequency: 'monthly', priority: 0.9 },
+  { path: '/qr-code-generator', lastModified: '2026-07-21', changeFrequency: 'monthly', priority: 0.9 },
+  { path: '/bitly-alternative', lastModified: '2026-07-21', changeFrequency: 'monthly', priority: 0.9 },
+  { path: '/url-shortener-api', lastModified: '2026-07-21', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/plans', lastModified: '2026-07-21', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/about', lastModified: '2026-07-21', changeFrequency: 'monthly', priority: 0.6 },
+];
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const lastModified = new Date();
+  const bilingual: MetadataRoute.Sitemap = BILINGUAL_PAGES.flatMap((entry) => {
+    const languages = {
+      en: enUrl(entry.path),
+      es: esUrl(entry.path),
+    };
+
+    return (['en', 'es'] as const).map((locale) => ({
+      url: locale === 'es' ? esUrl(entry.path) : enUrl(entry.path),
+      lastModified: new Date(entry.lastModified),
+      changeFrequency: entry.changeFrequency,
+      priority: entry.priority,
+      alternates: { languages },
+    }));
+  });
 
   return [
-    {
-      url: `${BASE_URL}/`,
-      lastModified,
-      changeFrequency: 'weekly',
-      priority: 1.0,
-    },
-    {
-      url: `${BASE_URL}/utm-builder`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/qr-code-generator`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/plans`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/about`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
+    ...bilingual,
+    // Página solo en español (canonical sin prefijo, se mantiene su URL histórica)
     {
       url: `${BASE_URL}/piscolas`,
-      lastModified,
+      lastModified: new Date('2026-07-21'),
       changeFrequency: 'monthly',
       priority: 0.5,
     },

--- a/src/app/ui/(main)/about/page.tsx
+++ b/src/app/ui/(main)/about/page.tsx
@@ -1,38 +1,21 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { useLocale, useTranslations } from "next-intl";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { ROUTES } from "@/lib/routes";
+import { buildPageMetadata, normalizeLocale } from "@/lib/seo/metadata";
 
 export async function generateMetadata(): Promise<Metadata> {
+  const locale = normalizeLocale(await getLocale());
   const t = await getTranslations("AboutPage");
-  const title = t("metaTitle");
-  const description = t("metaDescription");
 
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: "https://iny.one/about",
-      languages: {
-        en: "https://iny.one/about",
-        es: "https://iny.one/about",
-        "x-default": "https://iny.one/about",
-      },
-    },
-    openGraph: {
-      title,
-      description,
-      url: "/about",
-      images: ["/og-image.png"],
-    },
-    twitter: {
-      title,
-      description,
-      images: ["/og-image.png"],
-    },
-  };
+  return buildPageMetadata({
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    path: ROUTES.ABOUT,
+    locale,
+  });
 }
 
 const faqs = {

--- a/src/app/ui/(main)/bitly-alternative/page.tsx
+++ b/src/app/ui/(main)/bitly-alternative/page.tsx
@@ -1,0 +1,282 @@
+import type { Metadata } from "next";
+import { getLocale } from "next-intl/server";
+import { useLocale } from "next-intl";
+import Link from "next/link";
+import { ROUTES } from "@/lib/routes";
+import { buildPageMetadata, normalizeLocale } from "@/lib/seo/metadata";
+
+const META = {
+  en: {
+    title: "Bitly Alternative Without Ads — Free UTM + QR Codes (2026) | iny.one",
+    description:
+      "Bitly's free plan now shows an ad page before every redirect and caps you at 5 links a month. Compare honest free-plan limits of Bitly, TinyURL, Short.io, Dub and iny.one — a free shortener with UTM tracking, QR codes and no interstitials.",
+  },
+  es: {
+    title: "Alternativa a Bitly sin anuncios — UTM y QR gratis (2026) | iny.one",
+    description:
+      "El plan gratuito de Bitly ahora muestra una página de anuncios antes de cada redirección y te limita a 5 enlaces al mes. Compara los límites reales de Bitly, TinyURL, Short.io, Dub e iny.one — un acortador gratis con UTM, códigos QR y sin interstitials.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = normalizeLocale(await getLocale());
+  const m = META[locale];
+
+  return {
+    ...buildPageMetadata({
+      title: m.title,
+      description: m.description,
+      path: ROUTES.BITLY_ALTERNATIVE,
+      locale,
+    }),
+    keywords: [
+      "bitly alternative",
+      "free bitly alternative",
+      "bitly alternatives without ads",
+      "bitly free plan ads",
+      "url shortener without ads",
+      "alternativa a bitly",
+      "acortador sin anuncios",
+    ],
+    robots: { index: true, follow: true },
+  };
+}
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": "https://iny.one/bitly-alternative",
+      url: "https://iny.one/bitly-alternative",
+      name: "Bitly Alternative Without Ads — Free UTM + QR Codes",
+      description:
+        "Honest comparison of free URL shortener plans in 2026: Bitly, TinyURL, Short.io, Dub, Cuttly and iny.one.",
+      inLanguage: ["en", "es"],
+      isPartOf: { "@id": "https://iny.one/#website" },
+    },
+    {
+      "@type": "FAQPage",
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "Does Bitly's free plan show ads?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Yes. Since early 2025, links created on Bitly's free plan show an interstitial preview page that can include advertising before redirecting, and the change applies to previously created free-plan links as well. Removing it requires a paid plan.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Does iny.one show ads on short links?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "No. iny.one redirects straight to the destination with no advertising interstitial, on every tier including anonymous use.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "How many free links does iny.one allow?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "5 links per month without an account (these expire after 180 days), or 50 links per month with a free account, which never expire and include the analytics dashboard.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Can I migrate my existing Bitly links?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Existing bit.ly short codes cannot be transferred to another domain — that is true of any shortener. Old links keep redirecting (with Bitly's free-plan ad page), so the practical approach is to create new links on the new service going forward and replace links wherever you control them.",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+interface Row {
+  service: string;
+  links: string;
+  ads: string;
+  utm: string;
+  qr: string;
+  analytics: string;
+}
+
+const content = {
+  en: {
+    h1: "A Bitly Alternative Without Ads on Your Links",
+    intro:
+      "iny.one is a free URL shortener with built-in UTM tracking and QR codes that never inserts an advertising page before redirecting. If you landed here after seeing an ad on one of your own Bitly links, this page compares — with real numbers — what the main free plans actually give you in 2026.",
+    changedTitle: "What changed with Bitly's free plan",
+    changed:
+      "Bitly's free tier was the default shortener for over a decade. That product no longer exists in the same form: as of 2026 the free plan allows 5 new links and 2 QR codes per month, analytics are limited to total click counts, and — since early 2025 — free links show an interstitial preview page that can include advertising before sending visitors to the destination. The change applies retroactively to links created earlier on free accounts, and removing the ad page requires a paid plan. None of this makes Bitly a bad product; it makes the free plan a trial rather than a tool.",
+    tableTitle: "Free plans compared (verified July 2026)",
+    tableNote:
+      "Limits change often in this market — always re-check each vendor's pricing page before committing. Sources: each provider's own pricing and support pages.",
+    cols: { service: "Service", links: "Free links / month", ads: "Ad page on redirect", utm: "UTM tools", qr: "QR codes", analytics: "Free analytics" },
+    rows: [
+      { service: "iny.one", links: "5 anonymous · 50 with free account", ads: "Never", utm: "source, medium, campaign built-in", qr: "Free PNG, no watermark", analytics: "Clicks, countries, devices, browsers, referrers" },
+      { service: "Bitly", links: "5", ads: "Yes (interstitial with ads)", utm: "On paid campaigns tooling", qr: "2 / month", analytics: "Total clicks only" },
+      { service: "TinyURL", links: "Unlimited (anonymous)", ads: "No", utm: "No", qr: "Paid", analytics: "None" },
+      { service: "Short.io", links: "1,000 total (own domain required)", ads: "No", utm: "Yes", qr: "Yes", analytics: "Up to 50k tracked clicks / month" },
+      { service: "Dub", links: "25", ads: "No", utm: "Yes", qr: "Yes", analytics: "Full, developer-oriented" },
+      { service: "Cuttly", links: "30", ads: "No", utm: "UTM builder included", qr: "Yes", analytics: "30-day history" },
+    ] as Row[],
+    honestTitle: "Where iny.one fits — and where it doesn't",
+    honest:
+      "Honesty works both ways. iny.one is a good fit if you want clean redirects, UTM tagging and a QR code on every link without paying or seeing ads: 50 links a month on a free account covers most creators and small campaigns, and the dashboard shows countries, devices, browsers and referrers. It is not the right tool if you need branded custom domains (links live on iny.one), tens of thousands of links, or team seats — for high-volume branded links, Short.io's free tier is genuinely generous, and developers who want an open-source stack should also look at Dub.",
+    switchTitle: "Switching in three steps",
+    steps: [
+      "Create your next short link on the iny.one homepage — no account needed for the first ones.",
+      "Add utm_source, utm_medium and utm_campaign in the same form so analytics attribution keeps working.",
+      "Replace old links wherever you control them (bios, posts, printed QR codes) — existing bit.ly links keep redirecting, but on the free plan they show the ad page.",
+    ],
+    faqTitle: "Frequently asked questions",
+    faqs: [
+      { q: "Does Bitly's free plan show ads?", a: "Yes — since early 2025, free-plan links show an interstitial preview page that can include advertising, including links created before the change. Removing it requires a paid plan." },
+      { q: "Does iny.one show ads?", a: "No. Redirects go straight to the destination on every tier, with no interstitial." },
+      { q: "How many free links do I get on iny.one?", a: "5 per month without an account (they expire after 180 days), or 50 per month with a free account — those never expire and include full analytics." },
+      { q: "Can I move my existing bit.ly links here?", a: "Short codes can't be transferred between domains on any shortener. Old links keep working; create new ones here going forward and swap links where you control them." },
+    ],
+    ctaHome: "Create your first ad-free short link",
+    ctaUtm: "Or start from the UTM builder",
+  },
+  es: {
+    h1: "Una alternativa a Bitly sin anuncios en tus enlaces",
+    intro:
+      "iny.one es un acortador de URLs gratuito con seguimiento UTM y códigos QR integrados que nunca inserta una página de publicidad antes de redirigir. Si llegaste aquí después de ver un anuncio en uno de tus propios enlaces de Bitly, esta página compara — con números reales — qué ofrecen de verdad los principales planes gratuitos en 2026.",
+    changedTitle: "Qué cambió en el plan gratuito de Bitly",
+    changed:
+      "El nivel gratuito de Bitly fue el acortador por defecto durante más de una década. Ese producto ya no existe en la misma forma: en 2026 el plan gratuito permite 5 enlaces nuevos y 2 códigos QR al mes, la analítica se limita al total de clics y — desde inicios de 2025 — los enlaces gratuitos muestran una página interstitial de vista previa que puede incluir publicidad antes de enviar al visitante a su destino. El cambio aplica retroactivamente a enlaces creados antes en cuentas gratuitas, y quitar la página de anuncios requiere un plan de pago. Nada de esto hace de Bitly un mal producto; hace del plan gratuito una prueba más que una herramienta.",
+    tableTitle: "Planes gratuitos comparados (verificado julio 2026)",
+    tableNote:
+      "Los límites cambian seguido en este mercado — revisa siempre la página de precios de cada proveedor antes de decidir. Fuentes: las páginas de precios y soporte de cada servicio.",
+    cols: { service: "Servicio", links: "Enlaces gratis / mes", ads: "Anuncios al redirigir", utm: "Herramientas UTM", qr: "Códigos QR", analytics: "Analítica gratis" },
+    rows: [
+      { service: "iny.one", links: "5 anónimos · 50 con cuenta gratis", ads: "Nunca", utm: "source, medium y campaign integrados", qr: "PNG gratis, sin marca de agua", analytics: "Clics, países, dispositivos, navegadores, referentes" },
+      { service: "Bitly", links: "5", ads: "Sí (interstitial con publicidad)", utm: "En herramientas de pago", qr: "2 / mes", analytics: "Solo clics totales" },
+      { service: "TinyURL", links: "Ilimitados (anónimo)", ads: "No", utm: "No", qr: "De pago", analytics: "Ninguna" },
+      { service: "Short.io", links: "1.000 en total (requiere dominio propio)", ads: "No", utm: "Sí", qr: "Sí", analytics: "Hasta 50k clics medidos / mes" },
+      { service: "Dub", links: "25", ads: "No", utm: "Sí", qr: "Sí", analytics: "Completa, orientada a developers" },
+      { service: "Cuttly", links: "30", ads: "No", utm: "Generador UTM incluido", qr: "Sí", analytics: "Historial de 30 días" },
+    ] as Row[],
+    honestTitle: "Dónde encaja iny.one — y dónde no",
+    honest:
+      "La honestidad va en ambas direcciones. iny.one te sirve si quieres redirecciones limpias, etiquetado UTM y un código QR por enlace sin pagar ni ver anuncios: 50 enlaces al mes con cuenta gratuita cubren a la mayoría de creadores y campañas pequeñas, y el panel muestra países, dispositivos, navegadores y referentes. No es la herramienta correcta si necesitas dominios personalizados de marca (los enlaces viven en iny.one), decenas de miles de enlaces o asientos de equipo — para enlaces de marca en volumen, el nivel gratuito de Short.io es genuinamente generoso, y si eres developer y buscas stack open source, mira también Dub.",
+    switchTitle: "Cambiarse en tres pasos",
+    steps: [
+      "Crea tu próximo enlace corto en la portada de iny.one — no necesitas cuenta para los primeros.",
+      "Añade utm_source, utm_medium y utm_campaign en el mismo formulario para que la atribución en analítica siga funcionando.",
+      "Reemplaza los enlaces antiguos donde tú los controles (bios, publicaciones, códigos QR impresos) — los enlaces bit.ly existentes siguen redirigiendo, pero en el plan gratuito muestran la página de anuncios.",
+    ],
+    faqTitle: "Preguntas frecuentes",
+    faqs: [
+      { q: "¿El plan gratuito de Bitly muestra anuncios?", a: "Sí — desde inicios de 2025 los enlaces del plan gratuito muestran una página interstitial de vista previa que puede incluir publicidad, incluidos los enlaces creados antes del cambio. Quitarla requiere un plan de pago." },
+      { q: "¿iny.one muestra anuncios?", a: "No. Las redirecciones van directo al destino en todos los niveles, sin interstitial." },
+      { q: "¿Cuántos enlaces gratis tengo en iny.one?", a: "5 al mes sin cuenta (expiran a los 180 días), o 50 al mes con cuenta gratuita — esos no expiran e incluyen la analítica completa." },
+      { q: "¿Puedo migrar mis enlaces bit.ly existentes?", a: "Los códigos cortos no se pueden transferir entre dominios en ningún acortador. Los enlaces antiguos siguen funcionando; crea los nuevos aquí y reemplaza los enlaces donde tú los controles." },
+    ],
+    ctaHome: "Crea tu primer enlace corto sin anuncios",
+    ctaUtm: "O empieza desde el generador UTM",
+  },
+} as const;
+
+export default function BitlyAlternativePage() {
+  const locale = useLocale() as "es" | "en";
+  const t = content[locale] ?? content.en;
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),
+        }}
+      />
+
+      <div className="max-w-3xl mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-3">{t.h1}</h1>
+          <p className="text-lg text-gray-600">{t.intro}</p>
+        </div>
+
+        <section className="mt-12 space-y-10 text-gray-700">
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.changedTitle}</h2>
+            <p className="leading-relaxed">{t.changed}</p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.tableTitle}</h2>
+            <div className="overflow-x-auto rounded-lg shadow-sm">
+              <table className="min-w-full bg-white text-sm">
+                <thead>
+                  <tr className="bg-indigo-50 text-left text-gray-800">
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.cols.service}</th>
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.cols.links}</th>
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.cols.ads}</th>
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.cols.utm}</th>
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.cols.qr}</th>
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.cols.analytics}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {t.rows.map((row) => (
+                    <tr key={row.service} className="border-t border-gray-100 align-top">
+                      <th scope="row" className="px-4 py-3 font-semibold text-left text-indigo-700 whitespace-nowrap">
+                        {row.service}
+                      </th>
+                      <td className="px-4 py-3">{row.links}</td>
+                      <td className="px-4 py-3">{row.ads}</td>
+                      <td className="px-4 py-3">{row.utm}</td>
+                      <td className="px-4 py-3">{row.qr}</td>
+                      <td className="px-4 py-3">{row.analytics}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="text-xs text-gray-500 mt-2">{t.tableNote}</p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.honestTitle}</h2>
+            <p className="leading-relaxed">{t.honest}</p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.switchTitle}</h2>
+            <ol className="list-decimal list-inside space-y-2">
+              {t.steps.map((s, i) => (
+                <li key={i} className="leading-relaxed">{s}</li>
+              ))}
+            </ol>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.faqTitle}</h2>
+            <div className="space-y-4">
+              {t.faqs.map(({ q, a }) => (
+                <div key={q}>
+                  <h3 className="font-semibold text-gray-800">{q}</h3>
+                  <p className="text-sm mt-1 leading-relaxed">{a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <p className="text-sm space-x-4 pb-4">
+            <Link prefetch={false} href={ROUTES.HOME} className="text-indigo-600 hover:text-indigo-800 font-medium">
+              {t.ctaHome}
+            </Link>
+            <Link prefetch={false} href={ROUTES.UTM_BUILDER} className="text-indigo-600 hover:text-indigo-800 font-medium">
+              {t.ctaUtm}
+            </Link>
+          </p>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/src/app/ui/(main)/page.tsx
+++ b/src/app/ui/(main)/page.tsx
@@ -1,39 +1,22 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import HomeTitle from "@/components/HomeTitle";
 import UrlShortForm from "@/features/short_links/components/UrlShortForm";
 import UtmInfoSmall from "@/components/UtmInfoSmall";
 import SubscriptionUpgrade from "@/components/SubscriptionUpgrade";
 import HomeContent from "@/components/HomeContent";
+import { buildPageMetadata, normalizeLocale } from "@/lib/seo/metadata";
 
 export async function generateMetadata(): Promise<Metadata> {
+  const locale = normalizeLocale(await getLocale());
   const t = await getTranslations("Head");
-  const title = t("metaTitle");
-  const description = t("metaDescription");
 
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: "https://iny.one",
-      languages: {
-        en: "https://iny.one",
-        es: "https://iny.one",
-        "x-default": "https://iny.one",
-      },
-    },
-    openGraph: {
-      title,
-      description,
-      url: "/",
-      images: ["/og-image.png"],
-    },
-    twitter: {
-      title,
-      description,
-      images: ["/og-image.png"],
-    },
-  };
+  return buildPageMetadata({
+    title: t("metaTitle"),
+    description: t("metaDescription"),
+    path: "/",
+    locale,
+  });
 }
 
 export default function HomePage() {

--- a/src/app/ui/(main)/piscolas/page.tsx
+++ b/src/app/ui/(main)/piscolas/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Script from "next/script";
 import PiscolaCalculator from "@/features/piscolas/components/PiscolaCalculator";
 
 export const metadata: Metadata = {
@@ -92,15 +91,15 @@ const faqData = {
 export default function PiscolasPage() {
   return (
     <>
-      <Script
-        id="piscolas-jsonld"
+      {/* JSON-LD server-rendered: con next/script se inyectaba tras la
+          hidratación y no estaba en el HTML inicial que leen los crawlers. */}
+      <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData).replace(/</g, "\\u003c") }}
       />
-      <Script
-        id="piscolas-faq-jsonld"
+      <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqData) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqData).replace(/</g, "\\u003c") }}
       />
 
       <PiscolaCalculator />

--- a/src/app/ui/(main)/plans/page.tsx
+++ b/src/app/ui/(main)/plans/page.tsx
@@ -1,50 +1,234 @@
 import type { Metadata } from "next";
-import { getLocale, getTranslations } from "next-intl/server";
+import { getLocale } from "next-intl/server";
+import { useLocale } from "next-intl";
+import Link from "next/link";
 import PricingCards from "@/components/PricingCards";
-import { useTranslations } from "next-intl";
+import { ROUTES } from "@/lib/routes";
+import { buildPageMetadata, normalizeLocale } from "@/lib/seo/metadata";
+
+const META = {
+  en: {
+    title: "Plans & Pricing — Free URL Shortener with UTM | iny.one",
+    description:
+      "Start free: 50 short links per month with a free account, UTM tracking, QR codes and click analytics. Upgrade for higher limits and extra UTM parameters. No ads on any plan.",
+  },
+  es: {
+    title: "Planes y precios — Acortador de URLs con UTM | iny.one",
+    description:
+      "Empieza gratis: 50 enlaces cortos al mes con cuenta gratuita, seguimiento UTM, códigos QR y analítica de clics. Mejora tu plan para más límites y parámetros UTM extra. Sin anuncios en ningún plan.",
+  },
+} as const;
 
 export async function generateMetadata(): Promise<Metadata> {
-  const locale = await getLocale();
-  const t = await getTranslations("PlansPage");
+  const locale = normalizeLocale(await getLocale());
+  const m = META[locale];
 
-  const isEs = locale.startsWith("es");
-  const title = isEs ? `Planes – iny.one` : `Pricing Plans – iny.one`;
-  const description = isEs
-    ? "Compara los planes de iny.one y revisa qué funciones de acortamiento, UTM y analítica estarán disponibles."
-    : "Compare iny.one plans and see which shortening, UTM, and analytics features are available.";
-
-  return {
-    title,
-    description,
-    alternates: {
-      canonical: "https://iny.one/plans",
-      languages: {
-        en: "https://iny.one/plans",
-        es: "https://iny.one/plans",
-        "x-default": "https://iny.one/plans",
-      },
-    },
-    openGraph: {
-      title,
-      description,
-      url: "/plans",
-      images: ["/og-image.png"],
-    },
-    twitter: {
-      title,
-      description,
-      images: ["/og-image.png"],
-    },
-  };
+  return buildPageMetadata({
+    title: m.title,
+    description: m.description,
+    path: ROUTES.PLANS,
+    locale,
+  });
 }
 
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: [
+    {
+      "@type": "Question",
+      name: "Does iny.one show ads on short links?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "No. iny.one never inserts an advertising page before redirecting, on any plan — including the free and anonymous tiers.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Do iny.one short links expire?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Links created without an account expire after 180 days. Links created with any account (including the free plan) do not expire.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "How many links can I create for free?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Without an account: 5 links per month. With a free account: 50 links per month, plus the analytics dashboard with clicks, countries, devices, browsers and referrers.",
+      },
+    },
+    {
+      "@type": "Question",
+      name: "Which UTM parameters does each plan support?",
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: "Free plans support utm_source, utm_medium and utm_campaign. Basic adds utm_content and utm_term. Pro adds utm_id on top of all the others.",
+      },
+    },
+  ],
+};
+
+const content = {
+  en: {
+    h1: "Plans & Pricing",
+    intro:
+      "Every iny.one plan — including the free one — shortens URLs with UTM tracking and QR codes, and never inserts an ad page before redirecting. Paid plans raise your monthly limits and unlock extra UTM parameters.",
+    limitsTitle: "What each tier includes",
+    limits: [
+      {
+        name: "Anonymous (no account)",
+        desc: "5 links per month, utm_source / utm_medium / utm_campaign, free QR code per link. Links expire after 180 days.",
+      },
+      {
+        name: "Free account",
+        desc: "50 links per month that never expire, plus the full dashboard: total and unique clicks, top countries, devices, browsers and referrers.",
+      },
+      {
+        name: "Basic",
+        desc: "1,000 links per month and two extra UTM parameters: utm_content and utm_term — for A/B testing creatives and paid keywords.",
+      },
+      {
+        name: "Pro",
+        desc: "10,000 links per month and utm_id support for ads platforms, on top of everything in Basic.",
+      },
+    ],
+    faqTitle: "Pricing FAQ",
+    faqs: [
+      {
+        q: "Does iny.one show ads on short links?",
+        a: "No. There is no advertising interstitial before the redirect on any plan, free or paid.",
+      },
+      {
+        q: "Do short links expire?",
+        a: "Anonymous links expire after 180 days. Links created with any account — including the free plan — do not expire.",
+      },
+      {
+        q: "Can I start without a credit card?",
+        a: "Yes. Shortening works without an account, and the free account only requires signing in with Google.",
+      },
+      {
+        q: "Which UTM parameters does each plan support?",
+        a: "Free tiers: utm_source, utm_medium, utm_campaign. Basic adds utm_content and utm_term. Pro adds utm_id.",
+      },
+    ],
+    ctaTools: "Try the tools first:",
+    ctaShortener: "URL shortener",
+    ctaUtm: "UTM builder",
+    ctaQr: "QR code generator",
+  },
+  es: {
+    h1: "Planes y precios",
+    intro:
+      "Todos los planes de iny.one — incluido el gratuito — acortan URLs con seguimiento UTM y códigos QR, y nunca insertan una página de anuncios antes de redirigir. Los planes de pago suben tus límites mensuales y desbloquean parámetros UTM adicionales.",
+    limitsTitle: "Qué incluye cada nivel",
+    limits: [
+      {
+        name: "Anónimo (sin cuenta)",
+        desc: "5 enlaces al mes, utm_source / utm_medium / utm_campaign y código QR gratis por enlace. Los enlaces expiran a los 180 días.",
+      },
+      {
+        name: "Cuenta gratuita",
+        desc: "50 enlaces al mes que no expiran, más el panel completo: clics totales y únicos, países, dispositivos, navegadores y referentes.",
+      },
+      {
+        name: "Basic",
+        desc: "1.000 enlaces al mes y dos parámetros UTM extra: utm_content y utm_term — para testear creatividades y keywords de pago.",
+      },
+      {
+        name: "Pro",
+        desc: "10.000 enlaces al mes y soporte de utm_id para plataformas de anuncios, además de todo lo de Basic.",
+      },
+    ],
+    faqTitle: "Preguntas frecuentes sobre planes",
+    faqs: [
+      {
+        q: "¿iny.one muestra anuncios en los enlaces cortos?",
+        a: "No. No hay interstitial publicitario antes de la redirección en ningún plan, gratuito o de pago.",
+      },
+      {
+        q: "¿Los enlaces cortos expiran?",
+        a: "Los enlaces anónimos expiran a los 180 días. Los creados con cualquier cuenta — incluida la gratuita — no expiran.",
+      },
+      {
+        q: "¿Puedo empezar sin tarjeta de crédito?",
+        a: "Sí. Acortar funciona sin cuenta, y la cuenta gratuita solo requiere iniciar sesión con Google.",
+      },
+      {
+        q: "¿Qué parámetros UTM soporta cada plan?",
+        a: "Niveles gratuitos: utm_source, utm_medium, utm_campaign. Basic añade utm_content y utm_term. Pro añade utm_id.",
+      },
+    ],
+    ctaTools: "Prueba primero las herramientas:",
+    ctaShortener: "Acortador de URLs",
+    ctaUtm: "Generador UTM",
+    ctaQr: "Generador de códigos QR",
+  },
+} as const;
+
 export default function PlansPage() {
-  const t = useTranslations("PlansPage");
+  const locale = useLocale() as "es" | "en";
+  const t = content[locale] ?? content.en;
 
   return (
-    <div className="w-full min-h-screen bg-gray-50 flex flex-col items-center justify-center p-6">
-      <h2 className="text-3xl font-bold mb-10 text-gray-800">{t("title")}</h2>
-      <PricingCards logged={false} />
-    </div>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),
+        }}
+      />
+
+      <div className="w-full min-h-screen bg-gray-50 flex flex-col items-center p-6">
+        <div className="max-w-2xl text-center mt-6 mb-10">
+          <h1 className="text-4xl font-bold text-gray-800 mb-3">{t.h1}</h1>
+          <p className="text-lg text-gray-600">{t.intro}</p>
+        </div>
+
+        <PricingCards logged={false} />
+
+        <section className="max-w-2xl w-full mt-14 space-y-10 text-gray-700">
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.limitsTitle}</h2>
+            <dl className="space-y-3">
+              {t.limits.map(({ name, desc }) => (
+                <div key={name} className="bg-white rounded-lg p-4 shadow-sm">
+                  <dt className="font-semibold text-indigo-600">{name}</dt>
+                  <dd className="text-sm mt-1 leading-relaxed">{desc}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.faqTitle}</h2>
+            <div className="space-y-4">
+              {t.faqs.map(({ q, a }) => (
+                <div key={q}>
+                  <h3 className="font-semibold text-gray-800">{q}</h3>
+                  <p className="text-sm mt-1 leading-relaxed">{a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <p className="text-sm pb-8">
+            {t.ctaTools}{" "}
+            <Link prefetch={false} href={ROUTES.HOME} className="text-indigo-600 hover:text-indigo-800 font-medium">
+              {t.ctaShortener}
+            </Link>
+            {" · "}
+            <Link prefetch={false} href={ROUTES.UTM_BUILDER} className="text-indigo-600 hover:text-indigo-800 font-medium">
+              {t.ctaUtm}
+            </Link>
+            {" · "}
+            <Link prefetch={false} href={ROUTES.QR_GENERATOR} className="text-indigo-600 hover:text-indigo-800 font-medium">
+              {t.ctaQr}
+            </Link>
+          </p>
+        </section>
+      </div>
+    </>
   );
 }

--- a/src/app/ui/(main)/qr-code-generator/page.tsx
+++ b/src/app/ui/(main)/qr-code-generator/page.tsx
@@ -1,49 +1,47 @@
 import type { Metadata } from "next";
-import Script from "next/script";
+import { getLocale } from "next-intl/server";
 import { useLocale } from "next-intl";
 import Link from "next/link";
 import QrGenerator from "@/features/qr/components/QrGenerator";
 import { ROUTES } from "@/lib/routes";
+import { buildPageMetadata, normalizeLocale } from "@/lib/seo/metadata";
 
-const TITLE = "Free QR Code Generator — No Sign-Up, PNG Download | iny.one";
-const DESCRIPTION =
-  "Generate a QR code for any URL in seconds. Free, no sign-up, no watermark, high-resolution PNG download. Pair it with a short link to track scans.";
+const META = {
+  en: {
+    title: "Free QR Code Generator — No Sign-Up, PNG Download | iny.one",
+    description:
+      "Generate a QR code for any URL in seconds. Free, no sign-up, no watermark, high-resolution PNG download. Pair it with a short link to track scans.",
+  },
+  es: {
+    title: "Generador de códigos QR gratis — PNG sin registro | iny.one",
+    description:
+      "Genera un código QR para cualquier URL en segundos. Gratis, sin registro, sin marca de agua y con descarga PNG en alta resolución. Acorta el enlace primero para medir escaneos.",
+  },
+} as const;
 
-export const metadata: Metadata = {
-  title: TITLE,
-  description: DESCRIPTION,
-  keywords: [
-    "qr code generator",
-    "free qr code generator",
-    "qr code generator no sign up",
-    "create qr code free",
-    "qr code png download",
-    "generador de codigo qr gratis",
-    "crear codigo qr",
-  ],
-  robots: { index: true, follow: true },
-  alternates: {
-    canonical: "https://iny.one/qr-code-generator",
-    languages: {
-      en: "https://iny.one/qr-code-generator",
-      es: "https://iny.one/qr-code-generator",
-      "x-default": "https://iny.one/qr-code-generator",
-    },
-  },
-  openGraph: {
-    title: TITLE,
-    description: DESCRIPTION,
-    url: "/qr-code-generator",
-    type: "website",
-    images: ["/og-image.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: TITLE,
-    description: DESCRIPTION,
-    images: ["/og-image.png"],
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = normalizeLocale(await getLocale());
+  const m = META[locale];
+
+  return {
+    ...buildPageMetadata({
+      title: m.title,
+      description: m.description,
+      path: ROUTES.QR_GENERATOR,
+      locale,
+    }),
+    keywords: [
+      "qr code generator",
+      "free qr code generator",
+      "qr code generator no sign up",
+      "create qr code free",
+      "qr code png download",
+      "generador de codigo qr gratis",
+      "crear codigo qr",
+    ],
+    robots: { index: true, follow: true },
+  };
+}
 
 const structuredData = {
   "@context": "https://schema.org",
@@ -166,8 +164,9 @@ export default function QrCodeGeneratorPage() {
 
   return (
     <>
-      <Script
-        id="qr-generator-jsonld"
+      {/* JSON-LD server-rendered: con next/script se inyectaba tras la
+          hidratación y no estaba en el HTML inicial que leen los crawlers. */}
+      <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),

--- a/src/app/ui/(main)/url-shortener-api/page.tsx
+++ b/src/app/ui/(main)/url-shortener-api/page.tsx
@@ -1,0 +1,355 @@
+import type { Metadata } from "next";
+import { getLocale } from "next-intl/server";
+import { useLocale } from "next-intl";
+import Link from "next/link";
+import { ROUTES } from "@/lib/routes";
+import { buildPageMetadata, normalizeLocale } from "@/lib/seo/metadata";
+
+const META = {
+  en: {
+    title: "Free URL Shortener API — Create Short Links with One POST | iny.one",
+    description:
+      "Shorten URLs programmatically with a single JSON POST to https://iny.one/api/shorten. Free tier, UTM parameters built in, JSON responses, no API key required to start.",
+  },
+  es: {
+    title: "API de acortador de URLs gratis — crea enlaces con un POST | iny.one",
+    description:
+      "Acorta URLs por código con un solo POST JSON a https://iny.one/api/shorten. Nivel gratuito, parámetros UTM integrados, respuestas JSON y sin API key para empezar.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = normalizeLocale(await getLocale());
+  const m = META[locale];
+
+  return {
+    ...buildPageMetadata({
+      title: m.title,
+      description: m.description,
+      path: ROUTES.API_DOCS,
+      locale,
+    }),
+    keywords: [
+      "url shortener api",
+      "free url shortener api",
+      "link shortener api",
+      "shorten url api free",
+      "api acortador de url",
+      "api acortar enlaces",
+    ],
+    robots: { index: true, follow: true },
+  };
+}
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebAPI",
+      "@id": "https://iny.one/url-shortener-api#api",
+      name: "iny.one URL Shortener API",
+      description:
+        "REST endpoint that shortens a URL with optional UTM parameters and returns a JSON response with the short link.",
+      documentation: "https://iny.one/url-shortener-api",
+      provider: { "@id": "https://iny.one/#organization" },
+      termsOfService: "https://iny.one/about",
+    },
+    {
+      "@type": "FAQPage",
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "Is the iny.one API free?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Yes, within the same limits as the web app: 5 links per month per IP without an account, 50 per month with a free account, and up to 1,000 or 10,000 per month on the Basic and Pro plans.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Do I need an API key?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "No key is required for anonymous use. Authenticated calls currently reuse the same session as the web app; dedicated API keys are on the roadmap.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Is there a GET endpoint like /shorten?url=...?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "No. The API accepts POST requests with a JSON body only, which keeps destination URLs and UTM values out of server logs and referrer headers.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Do API-created links expire?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Links created without an account expire after 180 days. Links created while authenticated do not expire.",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const CURL_EXAMPLE = `curl -X POST https://iny.one/api/shorten \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "url": "https://example.com/landing",
+    "utm": {
+      "source": "newsletter",
+      "medium": "email",
+      "campaign": "july_launch"
+    }
+  }'`;
+
+const FETCH_EXAMPLE = `const res = await fetch("https://iny.one/api/shorten", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    url: "https://example.com/landing",
+    utm: { source: "newsletter", medium: "email", campaign: "july_launch" },
+  }),
+});
+
+const json = await res.json();
+// json.data.short -> "https://iny.one/abc1234"`;
+
+const RESPONSE_EXAMPLE = `{
+  "success": true,
+  "data": {
+    "short": "https://iny.one/abc1234"
+  },
+  "meta": {
+    "requestId": "3f6f4c1e-…",
+    "timestamp": "2026-07-21T12:00:00.000Z"
+  }
+}`;
+
+const ERROR_EXAMPLE = `{
+  "success": false,
+  "error": {
+    "code": "RATE_LIMIT_EXCEEDED",
+    "message": "…",
+    "status": 429,
+    "type": "…"
+  },
+  "meta": { "requestId": "…", "timestamp": "…" }
+}`;
+
+function CodeBlock({ code, label }: Readonly<{ code: string; label: string }>) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1">{label}</p>
+      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 overflow-x-auto text-xs leading-relaxed">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+const content = {
+  en: {
+    h1: "URL Shortener API",
+    intro:
+      "Create iny.one short links from your own scripts, backends or automations with a single JSON POST. The API applies the same UTM tagging, safety screening and analytics as the web shortener — and, like everything else here, it never puts an ad page in front of your visitors.",
+    endpointTitle: "Endpoint",
+    endpointDesc:
+      "One endpoint does the work. Send the destination URL plus a utm object with source, medium and campaign; pass empty strings for any UTM field you don't want to tag.",
+    requestTitle: "Request",
+    fields: [
+      { name: "url", type: "string · required", desc: "Destination URL. http(s) only; bare domains get https:// added. IP addresses and iny.one itself are rejected." },
+      { name: "utm.source", type: "string · required (may be empty)", desc: "Where the traffic comes from, e.g. newsletter, google. Sanitized to letters, numbers, hyphens and underscores." },
+      { name: "utm.medium", type: "string · required (may be empty)", desc: "Channel type, e.g. email, cpc, social." },
+      { name: "utm.campaign", type: "string · required (may be empty)", desc: "Campaign name, e.g. july_launch." },
+    ],
+    responseTitle: "Response",
+    responseDesc:
+      "Successful calls return HTTP 200 with the short link in data.short. Validation problems return 422, and hitting your monthly quota returns 429 — both with the same error envelope.",
+    limitsTitle: "Rate limits",
+    limits: [
+      { tier: "Anonymous (per IP)", limit: "5 links / month", note: "Links expire after 180 days" },
+      { tier: "Free account", limit: "50 links / month", note: "Links never expire; dashboard analytics included" },
+      { tier: "Basic", limit: "1,000 links / month", note: "Adds utm_content and utm_term" },
+      { tier: "Pro", limit: "10,000 links / month", note: "Adds utm_id" },
+    ],
+    limitsCols: { tier: "Tier", limit: "Limit", note: "Notes" },
+    notesTitle: "Good to know",
+    notes: [
+      "POST with a JSON body only — there is no GET /shorten?url= endpoint, so destinations never leak into logs or referrers.",
+      "Destination domains are screened against a blocklist of unsafe domains before a link is created.",
+      "Authenticated calls currently reuse the web session (cookies). Dedicated API keys are on the roadmap.",
+      "Redirects respond with an HTTP 307 and are excluded from search indexing, so your destination page keeps the SEO signals.",
+    ],
+    faqTitle: "API FAQ",
+    faqs: [
+      { q: "Is the API free?", a: "Yes, within the same monthly limits as the web app — see the table above. No credit card needed for the anonymous and free tiers." },
+      { q: "Do I need an API key?", a: "Not for anonymous use. Dedicated API keys are planned; today authenticated calls use the same session as the web app." },
+      { q: "Is there a GET endpoint?", a: "No — JSON POST only. It keeps URLs and UTM values out of server logs and referrer headers." },
+      { q: "Do API links expire?", a: "Anonymous links expire after 180 days; links created while signed in don't expire." },
+    ],
+    ctaPlans: "Need more volume? Compare plans",
+    ctaHome: "Prefer the web form? Shorten a URL",
+  },
+  es: {
+    h1: "API del acortador de URLs",
+    intro:
+      "Crea enlaces cortos de iny.one desde tus propios scripts, backends o automatizaciones con un solo POST JSON. La API aplica el mismo etiquetado UTM, la misma revisión de seguridad y la misma analítica que el acortador web — y, como todo aquí, nunca pone una página de anuncios delante de tus visitantes.",
+    endpointTitle: "Endpoint",
+    endpointDesc:
+      "Un solo endpoint hace el trabajo. Envía la URL de destino más un objeto utm con source, medium y campaign; pasa strings vacíos en los campos UTM que no quieras etiquetar.",
+    requestTitle: "Request",
+    fields: [
+      { name: "url", type: "string · requerido", desc: "URL de destino. Solo http(s); a los dominios sin protocolo se les añade https://. Se rechazan direcciones IP e iny.one mismo." },
+      { name: "utm.source", type: "string · requerido (puede ir vacío)", desc: "De dónde viene el tráfico, p. ej. newsletter, google. Se sanitiza a letras, números, guiones y guiones bajos." },
+      { name: "utm.medium", type: "string · requerido (puede ir vacío)", desc: "Tipo de canal, p. ej. email, cpc, social." },
+      { name: "utm.campaign", type: "string · requerido (puede ir vacío)", desc: "Nombre de campaña, p. ej. lanzamiento_julio." },
+    ],
+    responseTitle: "Respuesta",
+    responseDesc:
+      "Las llamadas exitosas devuelven HTTP 200 con el enlace corto en data.short. Los problemas de validación devuelven 422, y alcanzar tu cuota mensual devuelve 429 — ambos con el mismo formato de error.",
+    limitsTitle: "Límites de uso",
+    limits: [
+      { tier: "Anónimo (por IP)", limit: "5 enlaces / mes", note: "Los enlaces expiran a los 180 días" },
+      { tier: "Cuenta gratuita", limit: "50 enlaces / mes", note: "Los enlaces no expiran; incluye panel de analítica" },
+      { tier: "Basic", limit: "1.000 enlaces / mes", note: "Añade utm_content y utm_term" },
+      { tier: "Pro", limit: "10.000 enlaces / mes", note: "Añade utm_id" },
+    ],
+    limitsCols: { tier: "Nivel", limit: "Límite", note: "Notas" },
+    notesTitle: "Bueno saberlo",
+    notes: [
+      "Solo POST con cuerpo JSON — no existe un endpoint GET /shorten?url=, así los destinos no se filtran en logs ni referrers.",
+      "Los dominios de destino se revisan contra una lista de dominios inseguros antes de crear el enlace.",
+      "Las llamadas autenticadas hoy reutilizan la sesión web (cookies). Las API keys dedicadas están en el roadmap.",
+      "Las redirecciones responden con HTTP 307 y quedan excluidas del índice de búsqueda, así tu página de destino conserva las señales SEO.",
+    ],
+    faqTitle: "Preguntas frecuentes del API",
+    faqs: [
+      { q: "¿La API es gratis?", a: "Sí, dentro de los mismos límites mensuales que la app web — mira la tabla de arriba. Sin tarjeta para los niveles anónimo y gratuito." },
+      { q: "¿Necesito una API key?", a: "No para uso anónimo. Las API keys dedicadas están planificadas; hoy las llamadas autenticadas usan la misma sesión que la web." },
+      { q: "¿Hay endpoint GET?", a: "No — solo POST JSON. Así las URLs y los valores UTM no quedan en logs ni referrers." },
+      { q: "¿Los enlaces creados por API expiran?", a: "Los anónimos expiran a los 180 días; los creados con sesión iniciada no expiran." },
+    ],
+    ctaPlans: "¿Necesitas más volumen? Compara planes",
+    ctaHome: "¿Prefieres el formulario web? Acorta una URL",
+  },
+} as const;
+
+export default function UrlShortenerApiPage() {
+  const locale = useLocale() as "es" | "en";
+  const t = content[locale] ?? content.en;
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),
+        }}
+      />
+
+      <div className="max-w-3xl mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold text-gray-800 mb-3">{t.h1}</h1>
+          <p className="text-lg text-gray-600">{t.intro}</p>
+        </div>
+
+        <section className="mt-12 space-y-10 text-gray-700">
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.endpointTitle}</h2>
+            <p className="leading-relaxed mb-3">{t.endpointDesc}</p>
+            <p className="bg-white rounded-lg p-4 shadow-sm font-mono text-sm">
+              <span className="font-semibold text-indigo-600">POST</span>{" "}
+              https://iny.one/api/shorten
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.requestTitle}</h2>
+            <dl className="space-y-3 mb-6">
+              {t.fields.map(({ name, type, desc }) => (
+                <div key={name} className="bg-white rounded-lg p-4 shadow-sm">
+                  <dt className="font-mono text-sm font-semibold text-indigo-600">
+                    {name} <span className="text-gray-400 font-normal">— {type}</span>
+                  </dt>
+                  <dd className="text-sm mt-1">{desc}</dd>
+                </div>
+              ))}
+            </dl>
+            <div className="space-y-4">
+              <CodeBlock label="cURL" code={CURL_EXAMPLE} />
+              <CodeBlock label="JavaScript (fetch)" code={FETCH_EXAMPLE} />
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.responseTitle}</h2>
+            <p className="leading-relaxed mb-3">{t.responseDesc}</p>
+            <div className="space-y-4">
+              <CodeBlock label="200 OK" code={RESPONSE_EXAMPLE} />
+              <CodeBlock label="422 / 429" code={ERROR_EXAMPLE} />
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.limitsTitle}</h2>
+            <div className="overflow-x-auto rounded-lg shadow-sm">
+              <table className="min-w-full bg-white text-sm">
+                <thead>
+                  <tr className="bg-indigo-50 text-left text-gray-800">
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.limitsCols.tier}</th>
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.limitsCols.limit}</th>
+                    <th scope="col" className="px-4 py-3 font-semibold">{t.limitsCols.note}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {t.limits.map((row) => (
+                    <tr key={row.tier} className="border-t border-gray-100 align-top">
+                      <th scope="row" className="px-4 py-3 font-semibold text-left text-indigo-700 whitespace-nowrap">
+                        {row.tier}
+                      </th>
+                      <td className="px-4 py-3 whitespace-nowrap">{row.limit}</td>
+                      <td className="px-4 py-3">{row.note}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.notesTitle}</h2>
+            <ul className="list-disc list-inside space-y-2">
+              {t.notes.map((n, i) => (
+                <li key={i} className="leading-relaxed">{n}</li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">{t.faqTitle}</h2>
+            <div className="space-y-4">
+              {t.faqs.map(({ q, a }) => (
+                <div key={q}>
+                  <h3 className="font-semibold text-gray-800">{q}</h3>
+                  <p className="text-sm mt-1 leading-relaxed">{a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <p className="text-sm space-x-4 pb-4">
+            <Link prefetch={false} href={ROUTES.PLANS} className="text-indigo-600 hover:text-indigo-800 font-medium">
+              {t.ctaPlans}
+            </Link>
+            <Link prefetch={false} href={ROUTES.HOME} className="text-indigo-600 hover:text-indigo-800 font-medium">
+              {t.ctaHome}
+            </Link>
+          </p>
+        </section>
+      </div>
+    </>
+  );
+}

--- a/src/app/ui/(main)/utm-builder/page.tsx
+++ b/src/app/ui/(main)/utm-builder/page.tsx
@@ -1,49 +1,47 @@
 import type { Metadata } from "next";
-import Script from "next/script";
+import { getLocale } from "next-intl/server";
 import { useLocale } from "next-intl";
 import Link from "next/link";
 import UrlShortForm from "@/features/short_links/components/UrlShortForm";
 import { ROUTES } from "@/lib/routes";
+import { buildPageMetadata, normalizeLocale } from "@/lib/seo/metadata";
 
-const TITLE = "Free UTM Builder — Create, Tag & Shorten Campaign Links | iny.one";
-const DESCRIPTION =
-  "Build UTM links for Google Analytics in seconds: add utm_source, utm_medium and utm_campaign, then get a clean short link and QR code. Free, no sign-up.";
+const META = {
+  en: {
+    title: "Free UTM Builder — Create, Tag & Shorten Campaign Links | iny.one",
+    description:
+      "Build UTM links for Google Analytics in seconds: add utm_source, utm_medium and utm_campaign, then get a clean short link and QR code. Free, no sign-up.",
+  },
+  es: {
+    title: "Generador UTM gratis — crea, etiqueta y acorta enlaces | iny.one",
+    description:
+      "Crea enlaces UTM para Google Analytics en segundos: añade utm_source, utm_medium y utm_campaign y obtén un enlace corto con su código QR. Gratis y sin registro.",
+  },
+} as const;
 
-export const metadata: Metadata = {
-  title: TITLE,
-  description: DESCRIPTION,
-  keywords: [
-    "utm builder",
-    "free utm builder",
-    "utm generator",
-    "utm link builder",
-    "campaign url builder",
-    "generador utm",
-    "crear enlaces utm",
-  ],
-  robots: { index: true, follow: true },
-  alternates: {
-    canonical: "https://iny.one/utm-builder",
-    languages: {
-      en: "https://iny.one/utm-builder",
-      es: "https://iny.one/utm-builder",
-      "x-default": "https://iny.one/utm-builder",
-    },
-  },
-  openGraph: {
-    title: TITLE,
-    description: DESCRIPTION,
-    url: "/utm-builder",
-    type: "website",
-    images: ["/og-image.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: TITLE,
-    description: DESCRIPTION,
-    images: ["/og-image.png"],
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = normalizeLocale(await getLocale());
+  const m = META[locale];
+
+  return {
+    ...buildPageMetadata({
+      title: m.title,
+      description: m.description,
+      path: ROUTES.UTM_BUILDER,
+      locale,
+    }),
+    keywords: [
+      "utm builder",
+      "free utm builder",
+      "utm generator",
+      "utm link builder",
+      "campaign url builder",
+      "generador utm",
+      "crear enlaces utm",
+    ],
+    robots: { index: true, follow: true },
+  };
+}
 
 const structuredData = {
   "@context": "https://schema.org",
@@ -156,8 +154,9 @@ export default function UtmBuilderPage() {
 
   return (
     <>
-      <Script
-        id="utm-builder-jsonld"
+      {/* JSON-LD server-rendered: con next/script se inyectaba tras la
+          hidratación y no estaba en el HTML inicial que leen los crawlers. */}
+      <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(structuredData).replace(/</g, "\\u003c"),


### PR DESCRIPTION
Centralize page metadata handling with buildPageMetadata() helper for consistent canonical URLs and hreflang tags across all pages. Add three new content pages: custom 404, Bitly alternative comparison, and API documentation. Fix sitemap to include bilingual alternates and use stable lastModified dates instead of dynamic build dates. Refactor JSON-LD from Next.js Script component to native script tags for proper crawlability. Update all existing pages (home, plans, UTM builder, QR generator, about) to use the new metadata helper.