### PR TITLE
Add tests, logger, slug & rate-limit refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,301 +1,187 @@
 # iny.one
 
-Acortador de URLs con soporte para parámetros UTM, analítica básica de clics y arquitectura modular basada en Next.js App Router.
+Acortador de URLs con soporte para parámetros UTM, analítica de clics y una arquitectura modular sobre Next.js App Router.
+
+**Stack:** Next.js 15 (App Router) · React 19 · TypeScript · Tailwind CSS 4 · Supabase (Postgres + Auth) · next-intl · PayPal · Vercel
+
+---
+
+## Puesta en marcha
+
+```bash
+yarn install
+yarn typegen   # genera los tipos de ruta del App Router (RouteContext)
+yarn dev
+```
+
+| Script | Qué hace |
+| --- | --- |
+| `yarn dev` | Servidor de desarrollo con Turbopack |
+| `yarn build` / `yarn start` | Build de producción y arranque |
+| `yarn lint` | ESLint sobre `src` |
+| `yarn typecheck` | `tsc --noEmit` |
+| `yarn typegen` | Regenera los tipos de ruta de Next |
+| `yarn test` / `yarn coverage` | Jest, con o sin cobertura |
+| `yarn sonar` | Análisis de SonarQube |
+
+`yarn typecheck` requiere haber ejecutado antes `yarn typegen` o un `build`: el tipo global `RouteContext` lo genera Next a partir del árbol de rutas y no existe en un checkout limpio.
+
+### Variables de entorno
+
+| Variable | Uso |
+| --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Cliente de Supabase en navegador y middleware |
+| `NEXT_SUPABASE_URL` / `NEXT_SUPABASE_SERVICE_ROLE_KEY` | Cliente de servicio (service role) en el servidor |
+| `NEXT_PUBLIC_SITE_URL` | URL base para los redirects de OAuth |
+| `PAYPAL_PUBLIC_API_CLIENT_ID` / `PAYPAL_API_CLIENT_SECRET` / `PAYPAL_API_ENVIRONMENT` | Credenciales de PayPal |
+| `WEBHOOK_ID` | Identificador del webhook de PayPal usado al verificar firmas |
+| `LOG_LEVEL` | `debug` \| `info` \| `warn` \| `error` \| `silent` (por defecto `info` en producción) |
+| `CSP_REPORT_ONLY` | `true` publica la CSP como `Report-Only` en lugar de aplicarla |
+
+---
 
 ## Arquitectura
 
-El proyecto sigue esta dirección de dependencias:
+Dirección de dependencias:
 
 ```txt
-UI -> API -> Feature -> Core -> Infra
-
-Capas
-app/: punto de entrada del sistema. Define rutas, layouts, metadata, handlers y pages.
-features/: módulos funcionales por dominio. Aquí vive la UI específica, hooks y servicios de cada feature.
-core/: lógica de dominio pura. Entidades, contratos y casos de uso sin dependencias de framework.
-infra/: implementaciones concretas. Base de datos, auth, pagos, storage y adaptadores externos.
-lib/: utilidades transversales, middlewares, helpers y configuración compartida.
-
-src/
-├─ app/                              # App Router, pages, route handlers and layouts
-│  ├─ layout.tsx                     # Root layout (html, body, global metadata defaults)
-│  ├─ page.tsx                       # Public home page
-│  ├─ [short]/route.ts               # Short-link resolver
-│  ├─ api/                           # API routes
-│  │  ├─ auth/
-│  │  ├─ shorten/
-│  │  ├─ users/
-│  │  └─ payments/
-│  ├─ ui/                            # Internal implementation layer behind public rewrites
-│  │  ├─ layout.tsx                  # Section layout (without html/body)
-│  │  ├─ (main)/                     # Public-facing pages implemented internally
-│  │  │  ├─ page.tsx
-│  │  │  ├─ about/
-│  │  │  ├─ plans/
-│  │  │  ├─ piscolas/
-│  │  │  ├─ cart/
-│  │  │  │  └─ layout.tsx            # noindex for cart flows
-│  │  │  └─ auth/
-│  │  │     ├─ layout.tsx            # noindex for auth routes
-│  │  │     ├─ login/
-│  │  │     ├─ register/
-│  │  │     └─ callback/
-│  │  └─ dashboard/
-│  │     ├─ layout.tsx               # noindex for dashboard area
-│  │     ├─ page.tsx
-│  │     ├─ users/
-│  │     └─ settings/
-│  ├─ robots.txt                     # Crawl rules
-│  └─ sitemap.ts                     # Canonical sitemap
-│
-├─ components/                       # Shared UI components
-│  ├─ ui/
-│  ├─ layout/
-│  └─ feedback/
-│
-├─ features/                         # Feature/domain modules
-│  ├─ auth/
-│  ├─ payments/
-│  ├─ users/
-│  └─ ...
-│
-├─ core/                             # Domain layer
-│  ├─ entities/
-│  ├─ repositories/
-│  ├─ use-cases/
-│  └─ errors/
-│
-├─ infra/                            # Infrastructure adapters
-│  ├─ db/
-│  ├─ auth/
-│  ├─ payments/
-│  └─ storage/
-│
-├─ lib/                              # Shared utilities and runtime helpers
-│  ├─ api/
-│  ├─ middlewares/
-│  ├─ supabase/
-│  ├─ routes.ts
-│  ├─ reserved-slugs.ts              # Hard denylist for system/public routes
-│  └─ utils/
-│
-├─ hooks/                            # Global hooks
-├─ config/                           # App-wide configuration
-├─ styles/                           # Global styles
-├─ types/                            # Shared TypeScript types
-└─ tests/                            # Unit, integration and e2e tests
-Routing model
-
-El proyecto separa las rutas públicas de la implementación interna.
-
-Rutas públicas canónicas
-
-Estas son las URLs oficiales del sitio:
-
-/
-/about
-/plans
-/piscolas
-/auth/login
-/auth/register
-/dashboard
-/cart
-Rutas internas
-
-La carpeta app/ui/* contiene la implementación interna de las páginas.
-Estas rutas no deben promocionarse ni tratarse como canónicas.
-
-Ejemplos:
-
-/ui
-/ui/about
-/ui/plans
-/ui/piscolas
-/ui/auth/login
-
-## Enfoque
-
-Regla general
-Las rutas públicas limpias se exponen al usuario.
-next.config.ts usa rewrites para mapear esas rutas públicas a /ui/*.
-El acceso directo a /ui/* se corrige con redirects hacia la ruta pública correspondiente.
-
-SEO strategy
-
-El proyecto usa una estrategia SEO enfocada en consistencia canónica y separación entre páginas indexables y privadas.
-
-Host canónico
-Dominio canónico: https://iny.one
-www.iny.one redirige al apex
-Sitemap
-
-sitemap.ts incluye solo rutas públicas canónicas e indexables:
-
-/
-/about
-/plans
-/piscolas
-Robots
-
-robots.txt:
-
-permite rastreo del sitio público
-bloquea zonas privadas o administrativas
-referencia el sitemap canónico
-Metadata
-
-Se usa la Metadata API de Next.js para:
-
-metadata global en app/layout.tsx
-metadata específica por página en:
-home
-about
-plans
-piscolas
-Structured data
-
-La home incorpora JSON-LD para reforzar señales de sitio y producto.
-
-Noindex
-
-Las siguientes áreas quedan fuera del índice:
-
-auth
-dashboard
-cart
-
-Esto se aplica con robots: { index: false, follow: false } en layouts específicos.
-
-Short links
-
-Las rutas cortas resueltas por app/[short]/route.ts:
-
-no deben indexarse
-responden con X-Robots-Tag: noindex
-
-Reserved slugs
-
-El proyecto protege rutas críticas mediante una denylist centralizada en:
-
-src/lib/reserved-slugs.ts
-Objetivo
-
-Evitar que slugs cortos “roben” rutas del sistema o páginas públicas.
-
-La denylist se aplica en dos puntos
-Creación de short links
-src/app/api/shorten/route.ts
-los slugs autogenerados se regeneran si caen en una ruta reservada
-Resolución de short links
-src/app/[short]/route.ts
-si el slug solicitado está reservado, se responde 404 antes de consultar la base
-Ejemplos de rutas reservadas
-about
-plans
-piscolas
-auth
-login
-register
-dashboard
-cart
-api
-_next
-robots.txt
-sitemap.xml
-favicon.ico
-
-Enfoque de diseño
-1. Feature-first
-
-Cada módulo de negocio vive en features/.
-
-Ejemplos:
-
-features/auth
-features/users
-features/payments
-
-Esto evita un proyecto con lógica distribuida de forma caótica entre components/ y lib/.
-
-2. Separación de responsabilidades
-
-Inspirado en Clean Architecture:
-
-core/ → reglas de negocio puras
-infra/ → integraciones concretas
-features/ → UI + orquestación funcional
-app/ → routing, layouts, metadata, handlers
-
-Esto permite cambiar infraestructura sin reescribir la lógica de negocio.
-
-3. Adaptadores
-
-Los casos de uso del dominio dependen de interfaces; la infraestructura implementa esos contratos.
-
-Ejemplo:
-
-// core/repositories/UserRepository.ts
-export interface IUserRepository {
-  findByEmail(email: string): Promise<User | null>;
-  create(user: User): Promise<User>;
-}
-// infra/db/UserRepositorySupabase.ts
-import { supabase } from "@/lib/supabase";
-
-export class UserRepositorySupabase implements IUserRepository {
-  async findByEmail(email: string) {
-    const { data } = await supabase
-      .from("users")
-      .select("*")
-      .eq("email", email)
-      .single();
-
-    return data;
-  }
-
-  async create(user: User) {
-    // ...
-  }
-}
-// core/use-cases/RegisterUser.ts
-import { IUserRepository } from "../repositories/UserRepository";
-
-export class RegisterUser {
-  constructor(private repo: IUserRepository) {}
-
-  async execute(data: RegisterUserDTO) {
-    const existing = await this.repo.findByEmail(data.email);
-    if (existing) throw new Error("Email already registered");
-    return this.repo.create(data);
-  }
-}
-Technical notes
-Validación con Zod para payloads y esquemas
-Middlewares centralizados para sesión, auth y control de rutas
-Rutas públicas limpias con rewrites
-Protección dura de slugs reservados
-Metadata y canonicalización controladas desde App Router
-Recommended conventions
-Usar page.tsx para vistas
-Usar layout.tsx para composición y metadata compartida
-Usar route.ts para route handlers HTTP
-Mantener /ui/* como implementación interna, no como superficie pública
-Centralizar reglas de routing en lib/routes.ts
-Centralizar slugs reservados en lib/reserved-slugs.ts
-Future improvements
-Alias custom para short links con validación contra denylist
-Panel de analítica por enlace
-QR generator
-Gestión avanzada de campañas UTM
-Metadata/Open Graph específicas por herramienta o landing
-Tests de integración para rutas críticas y auth flow
-
+app/  →  features/  →  lib/  →  infra/
 ```
 
-### Recomendaciones
+Estructura real del repositorio:
 
-* Usa Zod para validar esquemas (lib/env.ts, inputs de APIs, etc.)
-* Usa React Query o SWR para data fetching.
-* Usa Context Providers dentro de app/layout.tsx para temas globales (auth, theme, etc.)
+```txt
+src/
+├─ app/                          # App Router: rutas, layouts, metadata y handlers
+│  ├─ layout.tsx                 # Layout raíz (html, body, metadata global, gtag)
+│  ├─ not-found.tsx
+│  ├─ robots.txt  ·  sitemap.ts  # Señales de rastreo e indexación
+│  ├─ [short]/route.tsx          # Resolución de short links y registro del clic
+│  ├─ api/                       # Route handlers
+│  │  ├─ auth/[slug]/            # login · register · confirm
+│  │  ├─ shorten/                # Creación de short links
+│  │  ├─ dashboard/stats/        # Métricas del panel
+│  │  ├─ checkout/paypal/        # Alta y captura de suscripciones
+│  │  └─ webhooks/               # Recepción de eventos de PayPal
+│  └─ ui/                        # Implementación interna tras los rewrites públicos
+│     ├─ (main)/                 # Home, about, plans, cart, auth y landings SEO
+│     ├─ (user)/dashboard/       # Panel del usuario
+│     └─ dashboard/layout.tsx    # noindex del área privada
+│
+├─ components/                   # UI compartida (Navbar, Footer, Tooltip, Skeleton…)
+│
+├─ features/                     # Módulos por dominio: componentes, hooks y servicios
+│  ├─ auth/  ·  payments/  ·  dashboard/
+│  ├─ short_links/  ·  qr/  ·  cart/  ·  piscolas/
+│
+├─ infra/                        # Adaptadores concretos
+│  ├─ db/                        # Repositorios sobre Supabase + mapeo de errores
+│  └─ payments/                  # Repositorios sobre la API de PayPal
+│
+├─ lib/                          # Utilidades transversales
+│  ├─ api/                       # Errores, códigos y forma de las respuestas
+│  ├─ cache/                     # Caché en memoria con TTL
+│  ├─ middlewares/               # Sesión y verificación de webhooks
+│  ├─ seo/                       # Metadata, canonical y hreflang
+│  ├─ short-links/               # Generación de slugs y construcción del destino
+│  ├─ supabase/                  # Fábricas de cliente (browser / server)
+│  ├─ utils/                     # rate limits, retry, geolocalización, url…
+│  ├─ logger.ts                  # Logger estructurado
+│  ├─ routes.ts                  # Rutas públicas y parámetros permitidos por plan
+│  └─ reserved-slugs.ts          # Denylist de slugs del sistema
+│
+├─ hooks/  ·  i18n/  ·  styles/  ·  types/
+│
+data/                            # Traducciones (en/es) y DTO de usuario
+scripts/                         # Mantenimiento de la denylist de dominios
+__tests__/                       # Tests unitarios y de rutas
+```
 
+### Criterios de diseño
 
+**Feature-first.** Cada dominio de negocio vive bajo `features/` con su UI, hooks y servicios, en lugar de repartir la lógica entre `components/` y `lib/`.
+
+**Repositorios como frontera de infraestructura.** El acceso a datos se concentra en `infra/db` y `infra/payments`, que exponen funciones fábrica (`getShorterRepository(db)`) recibiendo el cliente por parámetro. Eso mantiene las rutas ignorantes de Supabase y hace que los tests puedan sustituir el repositorio sin tocar la lógica.
+
+> **Nota.** No existe una capa `core/` con entidades y casos de uso: la lógica de dominio vive hoy en los servicios de cada feature y en `lib/`. Introducirla sería un refactor con sentido cuando la lógica de negocio crezca, pero este README describe el código tal como está.
+
+---
+
+## Modelo de rutas
+
+Las URLs públicas se exponen limpias y `next.config.ts` las reescribe hacia `/ui/*`, que es la implementación interna. El acceso directo a `/ui/*` se corrige con un redirect permanente hacia la ruta pública.
+
+Rutas públicas canónicas:
+
+```txt
+/  ·  /about  ·  /plans  ·  /piscolas  ·  /cart
+/utm-builder  ·  /qr-code-generator  ·  /bitly-alternative  ·  /url-shortener-api
+/auth/login  ·  /auth/register  ·  /auth/callback  ·  /dashboard
+```
+
+La versión en español vive bajo `/es/*` con URLs propias. El middleware inyecta la cabecera `x-iny-locale` (y borra la que llegue del cliente, para que no sea inyectable) y las mismas páginas de `/ui` renderizan contenido y metadata en español.
+
+### SEO
+
+- Dominio canónico `https://iny.one`; `www` redirige al apex.
+- `canonical` y `hreflang` por página vía `buildPageMetadata()` en `lib/seo/metadata.ts`.
+- El sitemap sólo incluye rutas públicas indexables.
+- `auth`, `dashboard` y `cart` quedan fuera del índice con `robots: { index: false }` en sus layouts.
+- Los short links responden con `X-Robots-Tag: noindex`.
+- Las landings incorporan JSON-LD.
+
+### Slugs reservados
+
+`lib/reserved-slugs.ts` centraliza la denylist para que un slug corto no pueda apropiarse de una ruta del sistema. Se aplica en dos puntos: al **crear** (los slugs autogenerados se regeneran si caen en la denylist) y al **resolver** (un slug reservado devuelve 404 antes de consultar la base de datos).
+
+---
+
+## Notas técnicas
+
+**Creación de short links.** El slug se genera con `nanoid` y se inserta de forma optimista: si Postgres devuelve una violación de índice único (`23505`), se genera un slug nuevo y se reintenta. Comprobar antes si el slug existe no eliminaría la condición de carrera y añadiría una consulta a cada creación.
+
+**Rate limiting.** `lib/utils/rate-limits.ts` aplica cuotas mensuales por plan. El consumo se cachea en memoria con TTL corto, de modo que sólo se consulta la base de datos en el primer acceso de cada ventana. El contador está detrás de la interfaz `UsageStore`: sustituirla por una implementación sobre Redis es el único cambio necesario para tener conteo exacto entre instancias.
+
+**Dominios bloqueados.** Un filtro de Bloom (`public/bloom.bin`) descarta la mayoría de dominios sin tocar la base de datos; sólo los positivos se confirman contra ella. Los scripts de `scripts/` regeneran la lista a partir de fuentes públicas.
+
+**Logging.** `lib/logger.ts` emite una línea JSON por evento en producción y texto legible en desarrollo, redactando claves sensibles en cualquier nivel del contexto. Se usa mediante loggers hijo con contexto ligado: `logger.child({ route: 'api/shorten' })`.
+
+**Cabeceras de seguridad.** Definidas en `next.config.ts`: HSTS, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` y una Content-Security-Policy con allowlist de orígenes.
+
+**Validación.** Zod para los payloads de las rutas de API y para la validación en cliente del formulario de acortado.
+
+---
+
+## Tests
+
+```bash
+yarn test              # suite completa
+yarn coverage          # con reporte de cobertura
+yarn test destination  # filtrando por nombre de fichero
+```
+
+Cubren la lógica con más riesgo: denylist de slugs, generación de slugs, construcción del destino con UTM, rate limiting, caché con TTL, retry, logger, estadísticas del dashboard y la ruta `/api/shorten` completa con Supabase mockeado.
+
+Los tests que tocan Server Components cortan en la frontera de datos (`@/data/dto/user-dto`, repositorios) en vez de cargar el cliente real de Supabase, que se distribuye como ESM y no pasa por el transform de Jest.
+
+## CI
+
+`.github/workflows/ci.yml` ejecuta lint, generación de tipos, typecheck, tests con cobertura y build en cada push y pull request contra `main` y `develop`.
+
+---
+
+## Convenciones
+
+- `page.tsx` para vistas, `layout.tsx` para composición y metadata compartida, `route.ts` para handlers HTTP.
+- `/ui/*` es implementación interna: no promocionar esas URLs ni tratarlas como canónicas.
+- Centralizar las rutas en `lib/routes.ts` y los slugs reservados en `lib/reserved-slugs.ts`.
+- Nada de `console.*` en código de servidor: usar `logger`.
+- El acceso a datos pasa siempre por un repositorio de `infra/`.
+
+## Pendientes
+
+- Endurecer la CSP con nonce por petición en lugar de `'unsafe-inline'` en `script-src`.
+- Alias personalizados para short links, validados contra la denylist.
+- Ampliar la cobertura de eventos de webhook de PayPal.
+- Automatizar el refresco de la lista de dominios bloqueados.
+- Mover el rate limiting a un store compartido cuando el tráfico lo justifique.

--- a/__mocks__/nanoid.js
+++ b/__mocks__/nanoid.js
@@ -1,0 +1,13 @@
+// Sustituto CJS de nanoid 5 (que sólo se publica como ESM) para el entorno de
+// test. Mantiene el contrato: identificador aleatorio del alfabeto url-safe.
+const ALPHABET = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLFGQZbfghjklqvwyzrict';
+
+function nanoid(size = 21) {
+  let id = '';
+  for (let index = 0; index < size; index++) {
+    id += ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
+  }
+  return id;
+}
+
+module.exports = { nanoid, customAlphabet: (alphabet, size) => () => nanoid(size) };

--- a/__mocks__/next-intl-server.js
+++ b/__mocks__/next-intl-server.js
@@ -1,0 +1,15 @@
+// `next-intl/server` se distribuye como ESM y no pasa por el transform de Jest,
+// lo que hacía fallar cualquier test que importara una página del App Router.
+const translate = (key) => key;
+translate.rich = (key) => key;
+translate.markup = (key) => key;
+translate.raw = (key) => key;
+translate.has = () => true;
+
+export const getTranslations = async () => translate;
+export const getLocale = async () => "en";
+export const getMessages = async () => ({});
+export const getNow = async () => new Date(0);
+export const getTimeZone = async () => "UTC";
+export const getFormatter = async () => ({});
+export const setRequestLocale = () => {};

--- a/__tests__/api/shorten.test.ts
+++ b/__tests__/api/shorten.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+import { ERROR } from '@/lib/api/error-codes';
+import { PG_ERROR } from '@/infra/db/db-errors';
+import { RATE_LIMITS, defaultUsageStore } from '@/lib/utils/rate-limits';
+
+const create = jest.fn();
+const isSafeDomain = jest.fn();
+const countLinksByIpInLastMonth = jest.fn();
+const countLinksByUserInLastMonth = jest.fn();
+const getCurrentUser = jest.fn();
+const bloomHas = jest.fn();
+
+jest.mock('@/infra/db/supabase_service', () => ({ supabase_service: {} }));
+jest.mock('@/lib/supabase/server', () => ({ createClient: jest.fn().mockResolvedValue({}) }));
+jest.mock('@/lib/utils/check_domain', () => ({ loadBloom: () => ({ has: bloomHas }) }));
+jest.mock('@/infra/db/shorter.repository', () => ({
+  getShorterRepository: () => ({
+    create,
+    isSafeDomain,
+    countLinksByIpInLastMonth,
+    countLinksByUserInLastMonth,
+  }),
+}));
+jest.mock('@/infra/db/user.repository', () => ({
+  getUserRepository: () => ({ getCurrentUser }),
+}));
+
+// Se importa después de registrar los mocks para que la ruta reciba los dobles.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { POST } = require('@/app/api/shorten/route') as typeof import('@/app/api/shorten/route');
+
+type ShortenBody = {
+  url: string;
+  utm?: { source: string; medium: string; campaign: string };
+};
+
+function request(body: ShortenBody, headers: Record<string, string> = {}) {
+  return new NextRequest('https://iny.one/api/shorten', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify({ utm: { source: '', medium: '', campaign: '' }, ...body }),
+  });
+}
+
+const anonymous = { 'x-forwarded-for': '203.0.113.10' };
+
+describe('POST /api/shorten', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    defaultUsageStore.clear();
+
+    bloomHas.mockReturnValue(false);
+    create.mockResolvedValue({ error: null });
+    isSafeDomain.mockResolvedValue({ data: true, error: null });
+    countLinksByIpInLastMonth.mockResolvedValue({ count: 0, error: null });
+    countLinksByUserInLastMonth.mockResolvedValue({ count: 0, error: null });
+    getCurrentUser.mockResolvedValue({ data: { user: null, role: null, plan: null } });
+  });
+
+  it('creates a short link and returns its url', async () => {
+    const response = await POST(request({ url: 'https://example.com' }), undefined);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.data.short).toMatch(/^https:\/\/iny\.one\/[a-z0-9_-]{7}$/i);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a payload that is not a valid url', async () => {
+    const response = await POST(request({ url: 'not a url' }), undefined);
+    const payload = await response.json();
+
+    expect(response.status).toBe(422);
+    expect(payload.error.code).toBe(ERROR.VALIDATION_ERROR);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects the shortener own domain', async () => {
+    const response = await POST(request({ url: 'https://iny.one/abc1234' }), undefined);
+
+    expect(response.status).toBe(422);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a domain flagged as unsafe', async () => {
+    bloomHas.mockReturnValue(true);
+    isSafeDomain.mockResolvedValue({ data: false, error: null });
+
+    const response = await POST(request({ url: 'https://malware.example' }), undefined);
+
+    expect(response.status).toBe(422);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('skips the database check when the bloom filter clears the domain', async () => {
+    await POST(request({ url: 'https://example.com' }), undefined);
+
+    expect(isSafeDomain).not.toHaveBeenCalled();
+  });
+
+  // Regresión: una colisión de nanoid devolvía un 500 sin reintentar.
+  it('retries with a fresh slug when the insert hits a unique violation', async () => {
+    create
+      .mockResolvedValueOnce({ error: { code: PG_ERROR.UNIQUE_VIOLATION } })
+      .mockResolvedValueOnce({ error: null });
+
+    const response = await POST(request({ url: 'https://example.com' }), undefined);
+
+    expect(response.status).toBe(200);
+    expect(create).toHaveBeenCalledTimes(2);
+
+    const [first, second] = create.mock.calls.map(([input]) => input.slug);
+    expect(first).not.toBe(second);
+  });
+
+  it('gives up after exhausting the slug attempts', async () => {
+    create.mockResolvedValue({ error: { code: PG_ERROR.UNIQUE_VIOLATION } });
+
+    const response = await POST(request({ url: 'https://example.com' }), undefined);
+
+    expect(response.status).toBe(500);
+    expect(create).toHaveBeenCalledTimes(5);
+  });
+
+  it('does not retry on an error that is not a collision', async () => {
+    create.mockResolvedValue({ error: { code: '42P01', message: 'relation does not exist' } });
+
+    const response = await POST(request({ url: 'https://example.com' }), undefined);
+
+    expect(response.status).toBe(500);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 429 once the anonymous quota is spent', async () => {
+    countLinksByIpInLastMonth.mockResolvedValue({
+      count: RATE_LIMITS.freeAnonymous,
+      error: null,
+    });
+
+    const response = await POST(request({ url: 'https://example.com' }, anonymous), undefined);
+    const payload = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(payload.error.code).toBe(ERROR.RATE_LIMIT_EXCEEDED);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('counts the created link so the next request sees the updated quota', async () => {
+    countLinksByIpInLastMonth.mockResolvedValue({
+      count: RATE_LIMITS.freeAnonymous - 1,
+      error: null,
+    });
+
+    const first = await POST(request({ url: 'https://example.com' }, anonymous), undefined);
+    expect(first.status).toBe(200);
+
+    const second = await POST(request({ url: 'https://example.org' }, anonymous), undefined);
+    expect(second.status).toBe(429);
+
+    // La segunda petición se resuelve desde la caché, sin volver a contar en base de datos.
+    expect(countLinksByIpInLastMonth).toHaveBeenCalledTimes(1);
+  });
+
+  // Regresión: un usuario autenticado sin plan en su metadata no pasaba por
+  // ninguna comprobación de cuota.
+  it('applies the free quota to an authenticated user with no plan', async () => {
+    getCurrentUser.mockResolvedValue({ data: { user: { id: 'user-1' }, role: null, plan: null } });
+    countLinksByUserInLastMonth.mockResolvedValue({ count: RATE_LIMITS.free, error: null });
+
+    const response = await POST(request({ url: 'https://example.com' }), undefined);
+
+    expect(response.status).toBe(429);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  // Regresión: cada parámetro ajeno a los UTM se sobreescribía con "undefined".
+  it('keeps the destination query parameters intact', async () => {
+    await POST(
+      request({
+        url: 'https://example.com/search?q=zapatillas&page=3',
+        utm: { source: 'instagram', medium: 'social', campaign: 'verano' },
+      }),
+      undefined,
+    );
+
+    const destination = new URL(create.mock.calls[0][0].destination);
+    expect(destination.searchParams.get('q')).toBe('zapatillas');
+    expect(destination.searchParams.get('page')).toBe('3');
+    expect(destination.searchParams.get('utm_source')).toBe('instagram');
+  });
+
+  it('stores an expiry only for anonymous links', async () => {
+    await POST(request({ url: 'https://example.com' }), undefined);
+    expect(create.mock.calls[0][0].expires).toMatchObject({ expires_in_days: 180 });
+
+    jest.clearAllMocks();
+    defaultUsageStore.clear();
+    create.mockResolvedValue({ error: null });
+    bloomHas.mockReturnValue(false);
+    countLinksByUserInLastMonth.mockResolvedValue({ count: 0, error: null });
+    getCurrentUser.mockResolvedValue({ data: { user: { id: 'user-1' }, role: null, plan: 'pro' } });
+
+    await POST(request({ url: 'https://example.com' }), undefined);
+    expect(create.mock.calls[0][0].expires).toBeUndefined();
+  });
+});

--- a/__tests__/features/dashboard-stats.test.ts
+++ b/__tests__/features/dashboard-stats.test.ts
@@ -1,0 +1,145 @@
+import { calcUserStats, categorizeReferer, NO_DATA } from '@/features/dashboard/helpers/stats';
+import type { UserDashboardStats } from '@/features/dashboard/services/getStats';
+import type { UserUrlStats } from '@/features/dashboard/types/types';
+
+const summary: UserDashboardStats['summary'] = {
+  date_start: '2026-01-01T00:00:00.000Z',
+  date_end: '2026-01-07T00:00:00.000Z',
+  clicks: 0,
+  clicks_last_24h: 0,
+  date_grouping: 'day',
+  stats: [],
+};
+
+const emptyAllTime: UserDashboardStats['all_time'] = {
+  clicks: 0,
+  top_browsers: [],
+  top_countries: [],
+};
+
+describe('calcUserStats', () => {
+  // Regresión: `all_time.top_countries[0].name` reventaba el dashboard de
+  // cualquier cuenta que todavía no hubiera recibido un solo clic.
+  it('does not throw for an account with no clicks yet', () => {
+    expect(() => calcUserStats([], summary, emptyAllTime, [])).not.toThrow();
+  });
+
+  it('reports the placeholder instead of crashing on empty rankings', () => {
+    const { general } = calcUserStats([], summary, emptyAllTime, []);
+
+    expect(general).toMatchObject({
+      totalLinks: 0,
+      totalClicks: 0,
+      clicksLast24h: NO_DATA,
+      topLink: NO_DATA,
+      topCountry: NO_DATA,
+    });
+  });
+
+  it('surfaces the top link and country when there is data', () => {
+    const urls: UserUrlStats[] = [
+      {
+        slug: 'aaa1111',
+        alias: null,
+        destination: 'https://example.com/a',
+        created_at: '2026-01-01T00:00:00.000Z',
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        clicks: 2,
+        stats: {
+          slug: 'aaa1111',
+          total_clicks: 2,
+          unique_ips: 2,
+          last_click_at: null,
+          country_counts: {},
+          browser_counts: {},
+          os_counts: {},
+          device_type_counts: {},
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      {
+        slug: 'bbb2222',
+        alias: null,
+        destination: 'https://example.com/b',
+        created_at: '2026-01-02T00:00:00.000Z',
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        clicks: 9,
+        stats: {
+          slug: 'bbb2222',
+          total_clicks: 9,
+          unique_ips: 7,
+          last_click_at: null,
+          country_counts: {},
+          browser_counts: {},
+          os_counts: {},
+          device_type_counts: {},
+          created_at: '2026-01-02T00:00:00.000Z',
+          updated_at: '2026-01-02T00:00:00.000Z',
+        },
+      },
+    ];
+
+    const { general, statsByClicks } = calcUserStats(
+      urls,
+      { ...summary, clicks_last_24h: 4 },
+      { clicks: 11, top_browsers: [], top_countries: [{ name: 'CL', value: 8 }] },
+      [],
+    );
+
+    expect(general).toMatchObject({
+      totalLinks: 2,
+      totalClicks: 11,
+      clicksLast24h: 4,
+      topLink: 'bbb2222',
+      topCountry: 'CL',
+    });
+    expect(statsByClicks[0].slug).toBe('bbb2222');
+  });
+
+  it('fills every day of the requested range', () => {
+    const { week } = calcUserStats([], summary, emptyAllTime, []);
+
+    expect(week.clicks).toHaveLength(7);
+    expect(week.clicks.every((value) => value === 0)).toBe(true);
+  });
+
+  it('computes referer percentages without producing NaN', () => {
+    const { traffic } = calcUserStats([], summary, emptyAllTime, [
+      { referer: 'https://www.instagram.com/', count: 3 },
+      { referer: '', count: 1 },
+    ]);
+
+    expect(traffic.Instagram.value).toBe(75);
+    expect(traffic.Direct.value).toBe(25);
+    expect(Object.values(traffic).every((item) => Number.isFinite(item.value))).toBe(true);
+  });
+
+  it('keeps percentages at zero when every referer has zero clicks', () => {
+    const { traffic } = calcUserStats([], summary, emptyAllTime, [
+      { referer: 'https://www.google.com/', count: 0 },
+    ]);
+
+    expect(traffic.Google.value).toBe(0);
+  });
+});
+
+describe('categorizeReferer', () => {
+  it.each([
+    ['https://www.facebook.com/page', 'Facebook'],
+    ['https://l.facebook.com/', 'Facebook'],
+    ['https://www.instagram.com/', 'Instagram'],
+    ['https://t.co-not-matching.com', 'Others'],
+    ['https://x.com/post', 'Twitter'],
+    ['https://wa.me/123', 'WhatsApp'],
+    ['https://lnkd.in/abc', 'LinkedIn'],
+    ['https://www.google.com/search', 'Google'],
+    ['', 'Direct'],
+  ])('classifies %s as %s', (referer, expected) => {
+    expect(categorizeReferer(referer)).toBe(expected);
+  });
+});

--- a/__tests__/index.test.tsx
+++ b/__tests__/index.test.tsx
@@ -1,11 +1,43 @@
-import { render } from '@testing-library/react'
-import Page from '@/app/ui/(main)/page';
+import { generateMetadata } from '@/app/ui/(main)/page';
 
 jest.mock('next/navigation');
 
-describe('Page', () => {
-  it('renders a heading', () => {
-    const { container } = render(<Page />)
-    expect(container).toMatchSnapshot();
-  })
-})
+// La home compone `SubscriptionUpgrade`, que arrastra el DTO de usuario y con él
+// el cliente de Supabase (ESM sin transformar en Jest). Se corta en esa
+// frontera: aquí se prueba la página, no el acceso a datos.
+jest.mock('@/data/dto/user-dto', () => ({
+  getCurrentUserDTO: jest.fn().mockResolvedValue(null),
+  isLoggedIn: jest.fn().mockResolvedValue(false),
+}));
+
+/**
+ * La home es un Server Component asíncrono, así que renderizarla con
+ * @testing-library/react no produce marcado (React no resuelve componentes
+ * servidor en el cliente). Lo que sí es verificable —y lo que de verdad importa
+ * en esta página— es la metadata: canonical y hreflang sostienen toda la
+ * estrategia SEO descrita en el README.
+ */
+describe('home page metadata', () => {
+  it('declares the canonical url and both hreflang alternates', async () => {
+    const metadata = await generateMetadata();
+
+    expect(metadata.alternates).toEqual({
+      canonical: 'https://iny.one',
+      languages: {
+        en: 'https://iny.one',
+        es: 'https://iny.one/es',
+        'x-default': 'https://iny.one',
+      },
+    });
+  });
+
+  it('exposes an OpenGraph card pointing at the canonical url', async () => {
+    const metadata = await generateMetadata();
+
+    expect(metadata.openGraph).toMatchObject({
+      url: 'https://iny.one',
+      siteName: 'iny.one',
+      type: 'website',
+    });
+  });
+});

--- a/__tests__/lib/logger.test.ts
+++ b/__tests__/lib/logger.test.ts
@@ -1,0 +1,88 @@
+import { logger } from '@/lib/logger';
+
+describe('logger', () => {
+  const spies = {
+    info: jest.spyOn(console, 'info').mockImplementation(() => {}),
+    warn: jest.spyOn(console, 'warn').mockImplementation(() => {}),
+    error: jest.spyOn(console, 'error').mockImplementation(() => {}),
+    debug: jest.spyOn(console, 'debug').mockImplementation(() => {}),
+  };
+
+  const originalLevel = process.env.LOG_LEVEL;
+
+  beforeAll(() => {
+    // jest.setup silencia el logger para el resto de la suite.
+    process.env.LOG_LEVEL = 'debug';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env.LOG_LEVEL = originalLevel;
+    Object.values(spies).forEach((spy) => spy.mockRestore());
+  });
+
+  /** Contexto con el que se llamó al último log (segundo argumento en dev). */
+  function lastContext(spy: jest.SpyInstance): Record<string, unknown> {
+    return spy.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+  }
+
+  it('routes each level to its console method', () => {
+    logger.info('a');
+    logger.warn('b');
+    logger.error('c');
+
+    expect(spies.info).toHaveBeenCalledTimes(1);
+    expect(spies.warn).toHaveBeenCalledTimes(1);
+    expect(spies.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges the bindings of a child logger into every event', () => {
+    logger.child({ route: 'api/shorten' }).info('created', { slug: 'abc1234' });
+
+    expect(lastContext(spies.info)).toMatchObject({ route: 'api/shorten', slug: 'abc1234' });
+  });
+
+  it('redacts sensitive keys at any depth', () => {
+    logger.child({ ip: '1.2.3.4' }).warn('blocked', {
+      user: { email: 'someone@example.com', id: 'user-1' },
+      authorization: 'Bearer token',
+    });
+
+    const context = lastContext(spies.warn);
+    expect(context.ip).toBe('[redacted]');
+    expect(context.authorization).toBe('[redacted]');
+    expect(context.user).toEqual({ email: '[redacted]', id: 'user-1' });
+  });
+
+  it('serializes errors with name, message and postgres code', () => {
+    const error = Object.assign(new Error('duplicate key'), { code: '23505' });
+
+    logger.error('insert failed', { error });
+
+    expect(lastContext(spies.error).error).toMatchObject({
+      name: 'Error',
+      message: 'duplicate key',
+      code: '23505',
+    });
+  });
+
+  it('truncates deeply nested structures instead of recursing forever', () => {
+    const deep = { a: { b: { c: { d: { e: 'too deep' } } } } };
+
+    logger.info('deep', deep);
+
+    expect(JSON.stringify(lastContext(spies.info))).toContain('[truncated]');
+  });
+
+  it('handles circular-free objects with arrays and dates', () => {
+    logger.info('payload', { items: [1, 2, 3], at: new Date('2026-01-01T00:00:00.000Z') });
+
+    expect(lastContext(spies.info)).toMatchObject({
+      items: [1, 2, 3],
+      at: '2026-01-01T00:00:00.000Z',
+    });
+  });
+});

--- a/__tests__/lib/rate-limits.test.ts
+++ b/__tests__/lib/rate-limits.test.ts
@@ -1,0 +1,151 @@
+import {
+  checkRateLimit,
+  MemoryUsageStore,
+  RATE_LIMITS,
+  recordRateLimitUsage,
+  resolveRateLimitPlan,
+  usageKey,
+} from '@/lib/utils/rate-limits';
+import type { ShorterRepository } from '@/infra/db/shorter.repository';
+
+type CountResult = { count: number | null; error: unknown };
+
+function repoStub(overrides: Partial<Record<'byUser' | 'byIp', CountResult>> = {}) {
+  const byUser = overrides.byUser ?? { count: 0, error: null };
+  const byIp = overrides.byIp ?? { count: 0, error: null };
+
+  const countLinksByUserInLastMonth = jest.fn().mockResolvedValue(byUser);
+  const countLinksByIpInLastMonth = jest.fn().mockResolvedValue(byIp);
+
+  return {
+    repo: { countLinksByUserInLastMonth, countLinksByIpInLastMonth } as unknown as ShorterRepository,
+    countLinksByUserInLastMonth,
+    countLinksByIpInLastMonth,
+  };
+}
+
+describe('resolveRateLimitPlan', () => {
+  it('treats a request without user as anonymous', () => {
+    expect(resolveRateLimitPlan(null, 'pro')).toBe('freeAnonymous');
+  });
+
+  it('honours the plan of an authenticated user', () => {
+    expect(resolveRateLimitPlan('user-1', 'pro')).toBe('pro');
+  });
+
+  // Regresión: antes, un usuario autenticado sin plan en su metadata salía del
+  // `else if` sin comprobación alguna y creaba links sin límite.
+  it('falls back to the free plan when the plan is missing', () => {
+    expect(resolveRateLimitPlan('user-1', null)).toBe('free');
+  });
+
+  it('falls back to the free plan when the plan is unknown', () => {
+    expect(resolveRateLimitPlan('user-1', 'enterprise' as never)).toBe('free');
+  });
+});
+
+describe('usageKey', () => {
+  it('buckets by user when there is a session', () => {
+    expect(usageKey('user-1', '1.2.3.4')).toBe('user:user-1');
+  });
+
+  it('buckets by ip for anonymous requests', () => {
+    expect(usageKey(null, '1.2.3.4')).toBe('ip:1.2.3.4');
+  });
+
+  it('uses a dedicated bucket when the ip cannot be resolved', () => {
+    expect(usageKey(null, null)).toBe('ip:unknown');
+  });
+});
+
+describe('checkRateLimit', () => {
+  let store: MemoryUsageStore;
+
+  beforeEach(() => {
+    store = new MemoryUsageStore();
+  });
+
+  it('allows a request below the limit', async () => {
+    const { repo } = repoStub({ byUser: { count: 3, error: null } });
+
+    const result = await checkRateLimit({ userId: 'user-1', plan: 'free', ip: null, repo, store });
+
+    expect(result).toMatchObject({
+      allowed: true,
+      plan: 'free',
+      limit: RATE_LIMITS.free,
+      used: 3,
+      remaining: RATE_LIMITS.free - 3,
+    });
+  });
+
+  it('denies a request once the limit is reached', async () => {
+    const { repo } = repoStub({ byIp: { count: RATE_LIMITS.freeAnonymous, error: null } });
+
+    const result = await checkRateLimit({ userId: null, plan: null, ip: '1.2.3.4', repo, store });
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+  });
+
+  // El objetivo del rediseño: dejar de ejecutar un COUNT por cada petición.
+  it('queries the database once and serves later checks from cache', async () => {
+    const { repo, countLinksByIpInLastMonth } = repoStub({ byIp: { count: 1, error: null } });
+    const input = { userId: null, plan: null, ip: '1.2.3.4', repo, store } as const;
+
+    await checkRateLimit(input);
+    await checkRateLimit(input);
+    await checkRateLimit(input);
+
+    expect(countLinksByIpInLastMonth).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts links created during the cached window', async () => {
+    const { repo } = repoStub({ byIp: { count: RATE_LIMITS.freeAnonymous - 1, error: null } });
+    const input = { userId: null, plan: null, ip: '1.2.3.4', repo, store } as const;
+
+    const first = await checkRateLimit(input);
+    expect(first.allowed).toBe(true);
+
+    recordRateLimitUsage(first, store);
+
+    const second = await checkRateLimit(input);
+    expect(second.allowed).toBe(false);
+  });
+
+  it('uses the user bucket instead of the ip bucket when there is a session', async () => {
+    const { repo, countLinksByUserInLastMonth, countLinksByIpInLastMonth } = repoStub();
+
+    await checkRateLimit({ userId: 'user-1', plan: 'basic', ip: '1.2.3.4', repo, store });
+
+    expect(countLinksByUserInLastMonth).toHaveBeenCalledWith('user-1');
+    expect(countLinksByIpInLastMonth).not.toHaveBeenCalled();
+  });
+
+  it('allows the request but does not cache when the count fails', async () => {
+    const { repo, countLinksByIpInLastMonth } = repoStub({
+      byIp: { count: null, error: { message: 'db down' } },
+    });
+    const input = { userId: null, plan: null, ip: '1.2.3.4', repo, store } as const;
+
+    const result = await checkRateLimit(input);
+    expect(result.allowed).toBe(true);
+
+    await checkRateLimit(input);
+    expect(countLinksByIpInLastMonth).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies the anonymous limit in memory when there is no ip', async () => {
+    const { repo, countLinksByIpInLastMonth } = repoStub();
+    const input = { userId: null, plan: null, ip: null, repo, store } as const;
+
+    for (let created = 0; created < RATE_LIMITS.freeAnonymous; created++) {
+      const result = await checkRateLimit(input);
+      expect(result.allowed).toBe(true);
+      recordRateLimitUsage(result, store);
+    }
+
+    expect((await checkRateLimit(input)).allowed).toBe(false);
+    expect(countLinksByIpInLastMonth).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/reserved-slugs.test.ts
+++ b/__tests__/lib/reserved-slugs.test.ts
@@ -1,0 +1,76 @@
+import {
+  getReservedSlugReason,
+  isReservedSlug,
+  normalizeSlug,
+} from '@/lib/reserved-slugs';
+
+describe('normalizeSlug', () => {
+  it('lowercases, trims and strips surrounding slashes', () => {
+    expect(normalizeSlug('  /Dashboard/ ')).toBe('dashboard');
+  });
+
+  it('decodes percent-encoded input', () => {
+    expect(normalizeSlug('%61bout')).toBe('about');
+  });
+});
+
+describe('isReservedSlug', () => {
+  it.each([
+    'about',
+    'plans',
+    'dashboard',
+    'auth',
+    'api',
+    'robots.txt',
+    'sitemap.xml',
+    'favicon.ico',
+    'es',
+    'en',
+  ])('rejects the system route "%s"', (slug) => {
+    expect(isReservedSlug(slug)).toBe(true);
+  });
+
+  it.each(['api/keys', 'dashboard/settings', 'es/about'])(
+    'rejects anything under the reserved prefix "%s"',
+    (slug) => {
+      expect(isReservedSlug(slug)).toBe(true);
+    },
+  );
+
+  it.each([
+    ['empty', ''],
+    ['hidden file', '.env'],
+    ['path traversal', '..'],
+    ['encoded slash', 'a%2fb'],
+    ['whitespace', 'my slug'],
+    ['only digits', '12345'],
+    ['only separators', '---'],
+    ['query fragment', 'abc?x=1'],
+  ])('rejects an unsafe slug (%s)', (_label, slug) => {
+    expect(isReservedSlug(slug)).toBe(true);
+  });
+
+  it('applies the denylist regardless of case or padding', () => {
+    expect(isReservedSlug('  DASHBOARD ')).toBe(true);
+  });
+
+  it.each(['abc1234', 'my-link', 'a1b2c3', 'promo_2026'])(
+    'accepts the regular slug "%s"',
+    (slug) => {
+      expect(isReservedSlug(slug)).toBe(false);
+    },
+  );
+});
+
+describe('getReservedSlugReason', () => {
+  it('explains why a slug was rejected', () => {
+    expect(getReservedSlugReason('dashboard')).toBe('Slug reservado por el sistema');
+    expect(getReservedSlugReason('api/keys')).toBe('Slug bajo prefijo reservado');
+    expect(getReservedSlugReason('..')).toBe('Slug inválido o riesgoso');
+    expect(getReservedSlugReason('')).toBe('Slug vacío');
+  });
+
+  it('returns null for an acceptable slug', () => {
+    expect(getReservedSlugReason('abc1234')).toBeNull();
+  });
+});

--- a/__tests__/lib/retry.test.ts
+++ b/__tests__/lib/retry.test.ts
@@ -1,0 +1,79 @@
+import { retry } from '@/lib/utils/retry';
+
+describe('retry', () => {
+  // `retry` avisa de cada intento fallido; los tests provocan fallos a propósito,
+  // así que se silencia la salida para no ensuciar el reporte.
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  afterAll(() => {
+    warnSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** Ejecuta la promesa dejando que los timers pendientes avancen. */
+  async function run<T>(promise: Promise<T>): Promise<T> {
+    const settled = promise.then(
+      (value) => ({ ok: true as const, value }),
+      (error) => ({ ok: false as const, error }),
+    );
+    await jest.runAllTimersAsync();
+    const result = await settled;
+    if (!result.ok) throw result.error;
+    return result.value;
+  }
+
+  it('returns the value without retrying when the call succeeds', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+
+    await expect(run(retry(fn))).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries until the call succeeds', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue('ok');
+
+    await expect(run(retry(fn))).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows the last error once the attempts run out', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('always fails'));
+
+    await expect(run(retry(fn, 3))).rejects.toThrow('always fails');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  /** Retrasos con los que `retry` programó cada espera entre intentos. */
+  async function collectDelays(call: () => Promise<unknown>): Promise<number[]> {
+    const spy = jest.spyOn(globalThis, 'setTimeout');
+    try {
+      await expect(run(call())).rejects.toThrow('boom');
+      return spy.mock.calls.map(([, delay]) => delay ?? 0);
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  // Regresión: el multiplicador venía por defecto en 0, así que el primer
+  // reintento ponía el retraso a 0 y anulaba el backoff exponencial.
+  it('grows the delay exponentially by default', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(collectDelays(() => retry(fn, 4, 100))).resolves.toEqual([100, 200, 400]);
+  });
+
+  it('keeps a constant delay when the multiplier is 1', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(collectDelays(() => retry(fn, 3, 50, 1))).resolves.toEqual([50, 50]);
+  });
+});

--- a/__tests__/lib/short-links/destination.test.ts
+++ b/__tests__/lib/short-links/destination.test.ts
@@ -1,0 +1,124 @@
+import { buildDestination, sanitizeUtmValue } from '@/lib/short-links/destination';
+
+describe('sanitizeUtmValue', () => {
+  it('strips characters outside the url-safe set', () => {
+    expect(sanitizeUtmValue('summer sale!/2026')).toBe('summersale2026');
+  });
+
+  it('returns null for empty input and for values that sanitize to nothing', () => {
+    expect(sanitizeUtmValue('')).toBeNull();
+    expect(sanitizeUtmValue(null)).toBeNull();
+    expect(sanitizeUtmValue(undefined)).toBeNull();
+    expect(sanitizeUtmValue('!!!')).toBeNull();
+  });
+});
+
+describe('buildDestination', () => {
+  const noUtm = { source: null, medium: null, campaign: null };
+
+  // Regresión: la implementación anterior recorría todos los parámetros de la
+  // query y reasignaba cada uno con `utm[nombre]`, de modo que cualquier
+  // parámetro ajeno a los UTM terminaba con el valor literal "undefined".
+  it('preserves query parameters that are not utm', () => {
+    const { destination } = buildDestination(
+      'https://example.com/search?q=hello&page=2',
+      noUtm,
+      'free',
+    );
+
+    const url = new URL(destination);
+    expect(url.searchParams.get('q')).toBe('hello');
+    expect(url.searchParams.get('page')).toBe('2');
+  });
+
+  it('keeps non-utm parameters intact while applying utm', () => {
+    const { destination } = buildDestination(
+      'https://example.com/product?id=42&ref=partner',
+      { source: 'instagram', medium: 'social', campaign: 'launch' },
+      'free',
+    );
+
+    const url = new URL(destination);
+    expect(url.searchParams.get('id')).toBe('42');
+    expect(url.searchParams.get('ref')).toBe('partner');
+    expect(url.searchParams.get('utm_source')).toBe('instagram');
+    expect(url.searchParams.get('utm_medium')).toBe('social');
+    expect(url.searchParams.get('utm_campaign')).toBe('launch');
+  });
+
+  it('drops utm parameters the plan does not allow', () => {
+    const { destination, utm } = buildDestination(
+      'https://example.com?utm_term=shoes&utm_id=123',
+      { source: 'newsletter' },
+      'free',
+    );
+
+    const url = new URL(destination);
+    expect(url.searchParams.has('utm_term')).toBe(false);
+    expect(url.searchParams.has('utm_id')).toBe(false);
+    // El valor se resuelve igualmente para persistirlo, aunque no viaje en la URL.
+    expect(utm.term).toBe('shoes');
+  });
+
+  it('keeps the extra utm parameters available to paid plans', () => {
+    const { destination } = buildDestination(
+      'https://example.com',
+      { source: 'ads', medium: 'cpc', campaign: 'q3', term: 'running', content: 'banner', id: 'abc' },
+      'pro',
+    );
+
+    const url = new URL(destination);
+    expect(url.searchParams.get('utm_term')).toBe('running');
+    expect(url.searchParams.get('utm_content')).toBe('banner');
+    expect(url.searchParams.get('utm_id')).toBe('abc');
+  });
+
+  it('lets explicit utm values win over the ones already in the url', () => {
+    const { utm } = buildDestination(
+      'https://example.com?utm_source=old',
+      { source: 'new' },
+      'free',
+    );
+
+    expect(utm.source).toBe('new');
+  });
+
+  it('falls back to the utm already present in the url', () => {
+    const { utm } = buildDestination(
+      'https://example.com?utm_source=newsletter&utm_medium=email',
+      { source: null, medium: null },
+      'free',
+    );
+
+    expect(utm.source).toBe('newsletter');
+    expect(utm.medium).toBe('email');
+  });
+
+  it('sanitizes utm values before writing them to the url', () => {
+    const { destination } = buildDestination(
+      'https://example.com',
+      { source: 'black friday!' },
+      'free',
+    );
+
+    expect(new URL(destination).searchParams.get('utm_source')).toBe('blackfriday');
+  });
+
+  it('removes unknown utm parameters', () => {
+    const { destination } = buildDestination(
+      'https://example.com?utm_whatever=1&keep=2',
+      noUtm,
+      'free',
+    );
+
+    const url = new URL(destination);
+    expect(url.searchParams.has('utm_whatever')).toBe(false);
+    expect(url.searchParams.get('keep')).toBe('2');
+  });
+
+  // Regresión: `decodeURI` lanza URIError ante un `%` suelto, lo que convertía
+  // la creación del link en un 500.
+  it('does not throw on urls with malformed percent sequences', () => {
+    expect(() => buildDestination('https://example.com/100%discount', noUtm, 'free')).not.toThrow();
+  });
+});

--- a/__tests__/lib/short-links/slug.test.ts
+++ b/__tests__/lib/short-links/slug.test.ts
@@ -1,0 +1,41 @@
+import {
+  generateSlug,
+  MAX_SLUG_GENERATION_ATTEMPTS,
+  SLUG_SIZE,
+  SlugGenerationError,
+} from '@/lib/short-links/slug';
+import { isReservedSlug } from '@/lib/reserved-slugs';
+
+describe('generateSlug', () => {
+  it('produces a slug of the requested length', () => {
+    expect(generateSlug()).toHaveLength(SLUG_SIZE);
+    expect(generateSlug(10)).toHaveLength(10);
+  });
+
+  it('never returns a reserved slug', () => {
+    for (let index = 0; index < 200; index++) {
+      expect(isReservedSlug(generateSlug())).toBe(false);
+    }
+  });
+
+  it('retries until it finds a candidate outside the denylist', () => {
+    const generate = jest.fn()
+      .mockReturnValueOnce('dashboard')
+      .mockReturnValueOnce('login')
+      .mockReturnValueOnce('abc1234');
+
+    expect(generateSlug(SLUG_SIZE, generate)).toBe('abc1234');
+    expect(generate).toHaveBeenCalledTimes(3);
+  });
+
+  it('lowercases the generated candidate', () => {
+    expect(generateSlug(SLUG_SIZE, () => 'AbCdEfG')).toBe('abcdefg');
+  });
+
+  it('throws once the attempts are exhausted', () => {
+    const generate = jest.fn().mockReturnValue('admin');
+
+    expect(() => generateSlug(SLUG_SIZE, generate)).toThrow(SlugGenerationError);
+    expect(generate).toHaveBeenCalledTimes(MAX_SLUG_GENERATION_ATTEMPTS);
+  });
+});

--- a/__tests__/lib/ttl-cache.test.ts
+++ b/__tests__/lib/ttl-cache.test.ts
@@ -1,0 +1,80 @@
+import { TtlCache } from '@/lib/cache/ttl-cache';
+
+describe('TtlCache', () => {
+  let now = 0;
+  const clock = () => now;
+
+  beforeEach(() => {
+    now = 0;
+  });
+
+  it('returns a stored value while it is still valid', () => {
+    const cache = new TtlCache<number>(1_000, 10, clock);
+    cache.set('a', 1);
+
+    now = 999;
+    expect(cache.get('a')).toBe(1);
+  });
+
+  it('expires a value once the ttl elapses', () => {
+    const cache = new TtlCache<number>(1_000, 10, clock);
+    cache.set('a', 1);
+
+    now = 1_000;
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it('updates a value in place', () => {
+    const cache = new TtlCache<number>(1_000, 10, clock);
+    cache.set('a', 1);
+    cache.update('a', (current) => current + 5);
+
+    expect(cache.get('a')).toBe(6);
+  });
+
+  it('ignores updates on missing or expired keys', () => {
+    const cache = new TtlCache<number>(1_000, 10, clock);
+    cache.update('missing', (current) => current + 1);
+    expect(cache.get('missing')).toBeUndefined();
+
+    cache.set('a', 1);
+    now = 2_000;
+    cache.update('a', (current) => current + 1);
+    expect(cache.get('a')).toBeUndefined();
+  });
+
+  it('does not extend the ttl when updating', () => {
+    const cache = new TtlCache<number>(1_000, 10, clock);
+    cache.set('a', 1);
+
+    now = 900;
+    cache.update('a', (current) => current + 1);
+
+    now = 1_000;
+    expect(cache.get('a')).toBeUndefined();
+  });
+
+  it('evicts the oldest entry when it exceeds the size cap', () => {
+    const cache = new TtlCache<number>(1_000, 2, clock);
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.set('c', 3);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('deletes and clears entries', () => {
+    const cache = new TtlCache<number>(1_000, 10, clock);
+    cache.set('a', 1);
+    cache.set('b', 2);
+
+    cache.delete('a');
+    expect(cache.get('a')).toBeUndefined();
+
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/__tests__/lib/url.test.ts
+++ b/__tests__/lib/url.test.ts
@@ -1,0 +1,30 @@
+import { safeDecodeURI } from '@/lib/utils/url';
+import { isUniqueViolation, PG_ERROR } from '@/infra/db/db-errors';
+
+describe('safeDecodeURI', () => {
+  it('decodes a well-formed uri', () => {
+    expect(safeDecodeURI('https://example.com/hello%20world')).toBe('https://example.com/hello world');
+  });
+
+  // Regresión: `decodeURI` lanza URIError ante un `%` que no abre una secuencia
+  // válida, lo que devolvía un 500 al resolver el link.
+  it('returns the input untouched when the uri is malformed', () => {
+    expect(safeDecodeURI('https://example.com/100%discount')).toBe('https://example.com/100%discount');
+  });
+});
+
+describe('isUniqueViolation', () => {
+  it('recognises the postgres unique violation code', () => {
+    expect(isUniqueViolation({ code: PG_ERROR.UNIQUE_VIOLATION })).toBe(true);
+  });
+
+  it.each([
+    ['another postgres error', { code: '23503' }],
+    ['an error without code', new Error('boom')],
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'error'],
+  ])('rejects %s', (_label, error) => {
+    expect(isUniqueViolation(error)).toBe(false);
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,29 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+/**
+ * El repositorio declaraba `eslint`, `eslint-config-next` y `typescript-eslint`
+ * y un script `lint`, pero no existía fichero de configuración, así que el
+ * comando fallaba antes de analizar nada.
+ */
+const eslintConfig = [
+  {
+    ignores: [
+      ".next/**",
+      "coverage/**",
+      "node_modules/**",
+      "next-env.d.ts",
+      // Fichero generado por la CLI de Supabase.
+      "src/lib/types/db.types.d.ts",
+      "data/lang/en.d.json.ts",
+    ],
+  },
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+];
+
+export default eslintConfig;

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,11 +14,22 @@ const config: Config = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   moduleNameMapper: {
     "^next-intl$": "<rootDir>/__mocks__/next-intl.js",
+    "^next-intl/server$": "<rootDir>/__mocks__/next-intl-server.js",
+    // `@/data/*` apunta a la carpeta `data/` de la raíz, no a `src/`.
+    // Debe declararse antes que el alias genérico para tener prioridad.
+    '^@/data/(.*)$': '<rootDir>/data/$1',
     '^@/(.*)$': '<rootDir>/src/$1',
+    // nanoid 5 sólo publica ESM, que Jest no puede cargar sin transformar
+    // node_modules. El sustituto replica su contrato (id aleatorio del alfabeto
+    // url-safe) para no alterar lo que se está probando.
+    '^nanoid$': '<rootDir>/__mocks__/nanoid.js',
   },
-  // transformIgnorePatterns: [
-  //   '/node_modules/(?!next-intl|use-intl)/',
-  // ],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/lib/types/**',
+  ],
+  coverageReporters: ['text-summary', 'lcov'],
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom'
+
+// Los tests ejercitan a propósito rutas de error que registran avisos. Silenciar
+// el logger por defecto mantiene el reporte legible; el test del propio logger
+// sube el nivel localmente.
+process.env.LOG_LEVEL = 'silent'

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,50 @@
 import { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 
+const isDev = process.env.NODE_ENV !== "production";
+
+/**
+ * Content-Security-Policy
+ *
+ * `script-src` incluye `'unsafe-inline'` porque hoy el sitio emite scripts en
+ * línea: el bootstrap de gtag en el layout raíz y un bloque JSON-LD por landing.
+ * Endurecerlo exige un nonce por petición generado en el middleware y propagado
+ * a cada uno de esos `<script>`; queda como siguiente paso, no como parte de
+ * este cambio.
+ *
+ * Aun con esa concesión, la directiva aporta lo que hoy falta: restringe de qué
+ * orígenes se puede cargar código, bloquea `object-src`, fija `base-uri` y
+ * `form-action`, y declara `frame-ancestors` (la versión moderna de
+ * X-Frame-Options, que se mantiene por compatibilidad con navegadores antiguos).
+ *
+ * Poner `CSP_REPORT_ONLY=true` publica la política como `Report-Only`, lo que
+ * permite validarla en producción sin romper nada antes de aplicarla.
+ */
+const supabaseOrigin = safeOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL);
+
+const PAYPAL_ORIGINS = ["https://www.paypal.com", "https://www.sandbox.paypal.com"];
+const ANALYTICS_ORIGINS = ["https://www.googletagmanager.com", "https://www.google-analytics.com"];
+
+const contentSecurityPolicy = [
+  ["default-src", "'self'"],
+  // 'unsafe-eval' sólo en desarrollo: lo necesita react-refresh.
+  ["script-src", "'self'", "'unsafe-inline'", ...(isDev ? ["'unsafe-eval'"] : []), ...ANALYTICS_ORIGINS, ...PAYPAL_ORIGINS],
+  ["style-src", "'self'", "'unsafe-inline'"],
+  ["img-src", "'self'", "data:", "blob:", "https://lh3.googleusercontent.com", ...ANALYTICS_ORIGINS, ...PAYPAL_ORIGINS],
+  ["font-src", "'self'", "data:"],
+  ["connect-src", "'self'", ...supabaseConnectSources(supabaseOrigin), ...ANALYTICS_ORIGINS, ...PAYPAL_ORIGINS],
+  ["frame-src", "'self'", ...PAYPAL_ORIGINS],
+  ["worker-src", "'self'", "blob:"],
+  ["manifest-src", "'self'"],
+  ["frame-ancestors", "'self'"],
+  ["base-uri", "'self'"],
+  ["form-action", "'self'"],
+  ["object-src", "'none'"],
+  ...(isDev ? [] : [["upgrade-insecure-requests"]]),
+]
+  .map((directive) => directive.join(" "))
+  .join("; ");
+
 const securityHeaders = [
   { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
   { key: "X-Frame-Options", value: "SAMEORIGIN" },
@@ -11,7 +55,29 @@ const securityHeaders = [
     value:
       "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()",
   },
+  {
+    key: process.env.CSP_REPORT_ONLY === "true"
+      ? "Content-Security-Policy-Report-Only"
+      : "Content-Security-Policy",
+    value: contentSecurityPolicy,
+  },
 ];
+
+/** Origen de una URL, o `null` si la variable falta o no es una URL válida. */
+function safeOrigin(url: string | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Supabase usa HTTPS para REST/Auth y WSS para Realtime. */
+function supabaseConnectSources(origin: string | null): string[] {
+  if (!origin) return [];
+  return [origin, origin.replace(/^https:/, "wss:")];
+}
 
 const nextConfig: NextConfig = {
   logging: {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "iny-one-full",
   "version": "1.0.0",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
+    "typegen": "next typegen",
     "test": "jest",
     "coverage": "jest --collect-coverage",
     "sonar": "sonar-scanner",

--- a/src/app/[short]/route.tsx
+++ b/src/app/[short]/route.tsx
@@ -7,6 +7,10 @@ import { supabase_service } from "@/infra/db/supabase_service";
 import { ROUTES } from "@/lib/routes";
 import { getTranslations, getLocale } from "next-intl/server";
 import { isReservedSlug, normalizeSlug } from '@/lib/reserved-slugs';
+import { safeDecodeURI } from '@/lib/utils/url';
+import { logger } from '@/lib/logger';
+
+const log = logger.child({ route: '[short]' });
 
 type IData = {
   destination: string | null;
@@ -28,7 +32,7 @@ export async function GET(request: NextRequest, ctx: RouteContext<'/[short]'>) {
   const { data: result, error } = await shorterRepo.getBySlug(short);
 
   if (error) {
-    console.error('getShortenUrl error:', error);
+    log.error('failed to resolve short link', { slug: short, error });
     return render404();
   }
 
@@ -61,7 +65,9 @@ export async function GET(request: NextRequest, ctx: RouteContext<'/[short]'>) {
     });
   });
 
-  const destination = decodeURI(data.destination);
+  // safeDecodeURI: un destino con un `%` suelto haría que `decodeURI` lance
+  // URIError y convertiría cada visita al link en un 500.
+  const destination = safeDecodeURI(data.destination);
   const response = NextResponse.redirect(destination, 307);
   response.headers.set('X-Robots-Tag', 'noindex');
   return response;

--- a/src/app/api/shorten/route.ts
+++ b/src/app/api/shorten/route.ts
@@ -1,24 +1,37 @@
 import { withErrorHandling } from "@/lib/api/http";
 import { NextRequest } from "next/server";
-import { nanoid } from "nanoid";
 import { parse as parseUrl } from "tldts";
-import { PlanName, UrlExpires, UtmParams } from "@/lib/types";
+import { PlanName } from "@/lib/types";
 import { loadBloom } from "@/lib/utils/check_domain";
 import * as z from "zod/mini";
 import { ApiError, ValidationError } from "@/lib/api/errors";
 import { successResponse } from "@/lib/api/responses";
 import { getUserRepository } from "@/infra/db/user.repository";
-import { getShorterRepository } from "@/infra/db/shorter.repository";
+import {
+  getShorterRepository,
+  type CreateShortLinkInput,
+  type ShorterRepository,
+} from "@/infra/db/shorter.repository";
 import { supabase_service } from "@/infra/db/supabase_service";
+import { isUniqueViolation } from "@/infra/db/db-errors";
 import { createClient } from "@/lib/supabase/server";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { checkRateLimit } from "@/lib/utils/rate-limits";
+import { checkRateLimit, recordRateLimitUsage } from "@/lib/utils/rate-limits";
 import { ERROR } from "@/lib/api/error-codes";
-import { ALLOWED_PARAMS } from "@/lib/routes";
-import { isReservedSlug } from "@/lib/reserved-slugs";
+import { generateSlug, MAX_SLUG_INSERT_ATTEMPTS } from "@/lib/short-links/slug";
+import { buildDestination, type DestinationPlan } from "@/lib/short-links/destination";
+import { logger } from "@/lib/logger";
 
 dayjs.extend(utc);
+
+const log = logger.child({ route: 'api/shorten' });
+
+/** Días de vigencia de un link creado sin cuenta. */
+const ANONYMOUS_LINK_TTL_DAYS = 180;
+
+/** Dominios que nunca pueden ser destino de un link. */
+const BLOCKED_DOMAINS = new Set(['iny.one', 'localhost']);
 
 const schemaShortenBody = z.object({
   url: z.url({
@@ -32,130 +45,128 @@ const schemaShortenBody = z.object({
   })
 });
 
-const generateSafeSlug = (size = 7, maxAttempts = 25): string => {
-  for (let i = 0; i < maxAttempts; i++) {
-    const candidate = nanoid(size).toLowerCase();
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const body = schemaShortenBody.safeParse(await request.json());
 
-    if (!isReservedSlug(candidate)) {
-      return candidate;
-    }
-  }
-
-  throw new ApiError("SERVER_ERROR", "could not generate a valid slug", { status: 500 });
-};
-
-export const POST = withErrorHandling(async (request: NextRequest, ctx: RouteContext<'/api/shorten'>) => {
-  const bodyNoValidated = await request.json();
-  const body = schemaShortenBody.safeParse(bodyNoValidated);
-
-  if (!body.success || body.error) {
+  if (!body.success) {
     throw new ValidationError();
   }
 
   const { url, utm } = body.data;
 
-  const ip = (request.headers.get('x-vercel-forwarded-for')
-            ?? request.headers.get('x-forwarded-for')
-            ?? request.headers.get('x-real-ip') ?? null) as string;
-  const countryCode = (request.headers.get('x-vercel-ip-country') ?? null) as string;
+  const ip = request.headers.get('x-vercel-forwarded-for')
+    ?? request.headers.get('x-forwarded-for')
+    ?? request.headers.get('x-real-ip');
+  const countryCode = request.headers.get('x-vercel-ip-country');
 
-  let urlWithSuffix = url.trim();
-  if (!/^https?:\/\//i.test(urlWithSuffix)) {
-    urlWithSuffix = 'https://' + urlWithSuffix;
-  }
+  const target = withProtocol(url.trim());
+  const urlInfo = parseUrl(target);
 
-  const urlInfo = parseUrl(urlWithSuffix);
-  if (urlInfo.domain === null || urlInfo.isIp || ["iny.one", "localhost"].includes(urlInfo.domain)) {
-    console.log('❌ La URL ingresada no es válida:', urlWithSuffix);
+  if (urlInfo.domain === null || urlInfo.isIp || BLOCKED_DOMAINS.has(urlInfo.domain)) {
+    log.info('rejected destination url', { domain: urlInfo.domain, isIp: urlInfo.isIp });
     throw new ValidationError("Invalid url provided");
   }
 
   const shorterRepo = getShorterRepository(supabase_service);
-
-  const bannedDomains = loadBloom();
-  if (bannedDomains.has(urlInfo.domain)) {
-    const urlBanned = await shorterRepo.isSafeDomain(urlInfo.domain);
-
-    if (urlBanned.error) {
-      console.error(urlBanned.error);
-      throw new ValidationError("Error when validating url");
-    }
-
-    if (urlBanned.data !== null && urlBanned.data === false) {
-      console.log('❗ El dominio de la URL ingresada está baneada:', urlWithSuffix);
-      throw new ValidationError("Error when validating url");
-    }
-  }
+  await assertDomainIsAllowed(urlInfo.domain, shorterRepo);
 
   const supabase = await createClient();
   const userRepo = getUserRepository(supabase);
   const { data: currUser } = await userRepo.getCurrentUser();
 
-  const slug = generateSafeSlug(7);
-  const user_id = currUser.user?.id ?? null;
+  const userId = currUser.user?.id ?? null;
   const plan = currUser.plan;
 
-  const { destination, utm: utmParams } = buildDestination(urlWithSuffix, utm, plan ?? 'freeAnonymous');
-  
-
-  const rateLimitResult = await checkRateLimit(user_id, plan, ip, shorterRepo);
-  if (!rateLimitResult.allowed) {
-    throw new ApiError(ERROR.RATE_LIMIT_EXCEEDED, rateLimitResult.message || "Rate limit exceeded", { status: 429 });
+  const rateLimit = await checkRateLimit({ userId, plan, ip, repo: shorterRepo });
+  if (!rateLimit.allowed) {
+    throw new ApiError(
+      ERROR.RATE_LIMIT_EXCEEDED,
+      `Monthly limit reached for plan ${rateLimit.plan}: ${rateLimit.limit} links.`,
+      { status: 429 },
+    );
   }
 
-  let expires: UrlExpires | undefined;
-  if (!user_id) {
-    const expires_in_days = 180;
-    expires = {
-      expires_in_days,
-      expires_at: dayjs.utc().add(expires_in_days, 'day').toISOString()
-    };
-  }
+  const { destination, utm: utmParams } = buildDestination(target, utm, toDestinationPlan(plan, userId));
 
-  const { error } = await shorterRepo.create(user_id, slug, destination, utmParams, urlInfo.domain, expires, {
-    ip,
-    countryCode,
+  const slug = await createWithUniqueSlug(shorterRepo, {
+    userId,
+    destination,
+    utm: utmParams,
+    domain: urlInfo.domain,
+    expires: userId ? undefined : buildAnonymousExpiry(),
+    client: { ip, countryCode },
   });
 
-  if (error) {
-    console.error('Supabase insert error:', error);
-    throw new ApiError("SERVER_ERROR", "internal server error", { status: 500 });
-  }
+  recordRateLimitUsage(rateLimit);
 
   return successResponse({
     short: `https://iny.one/${slug}`
   });
 });
 
-const buildDestination = (url: string, utm: Partial<UtmParams>, plan: PlanName | 'freeAnonymous') => {
-  const sanitize = (value: string | null) =>
-    value?.replaceAll(/[^a-zA-Z0-9-_]/g, '');
+function withProtocol(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`;
+}
 
-  const destination = new URL(url);
-  const utmDestination: UtmParams = {
-    source: sanitize(utm?.source ?? destination.searchParams.get('utm_source')) ?? null as unknown as string,
-    medium: sanitize(utm?.medium ?? destination.searchParams.get('utm_medium')) ?? null as unknown as string,
-    campaign: sanitize(utm?.campaign ?? destination.searchParams.get('utm_campaign')) ?? null as unknown as string,
-    term: sanitize(utm?.term ?? destination.searchParams.get('utm_term')) ?? null as unknown as string,
-    content: sanitize(utm?.content ?? destination.searchParams.get('utm_content')) ?? null as unknown as string,
-    id: sanitize(utm?.id ?? destination.searchParams.get('utm_id')) ?? null as unknown as string,
-  };
+function toDestinationPlan(plan: PlanName | null, userId: string | null): DestinationPlan {
+  if (!userId) return 'freeAnonymous';
+  return plan ?? 'free';
+}
 
-  if (utmDestination.source) destination.searchParams.set('utm_source', utmDestination.source);
-  if (utmDestination.medium) destination.searchParams.set('utm_medium', utmDestination.medium);
-  if (utmDestination.campaign) destination.searchParams.set('utm_campaign', utmDestination.campaign);
-
-  const allowdParams = ALLOWED_PARAMS[plan];
-  destination.searchParams.keys().forEach((param) => {
-    if (param.startsWith('utm_') && !allowdParams.includes(param)) {
-      destination.searchParams.delete(param);
-    } else {
-      destination.searchParams.set(param, utmDestination[param.replace('utm_', '') as keyof UtmParams]);
-    }
-  });
-
+function buildAnonymousExpiry() {
   return {
-    destination: decodeURI(destination.toString()),
-    utm: utmDestination,
+    expires_in_days: ANONYMOUS_LINK_TTL_DAYS,
+    expires_at: dayjs.utc().add(ANONYMOUS_LINK_TTL_DAYS, 'day').toISOString(),
   };
-};
+}
+
+/**
+ * El filtro de Bloom descarta la mayoría de dominios sin tocar la base de datos;
+ * sólo los positivos (incluidos los falsos positivos) se confirman contra ella.
+ */
+async function assertDomainIsAllowed(domain: string, repo: ShorterRepository): Promise<void> {
+  if (!loadBloom().has(domain)) return;
+
+  const { data, error } = await repo.isSafeDomain(domain);
+
+  if (error) {
+    log.error('domain safety check failed', { domain, error });
+    throw new ValidationError("Error when validating url");
+  }
+
+  if (data === false) {
+    log.warn('blocked banned domain', { domain });
+    throw new ValidationError("Error when validating url");
+  }
+}
+
+/**
+ * Inserta el link generando un slug nuevo en cada intento.
+ *
+ * Se inserta de forma optimista en lugar de comprobar antes si el slug existe:
+ * una comprobación previa no elimina la condición de carrera (dos peticiones
+ * simultáneas podrían leer «libre» y chocar igual) y añade una consulta a cada
+ * creación. El índice único de la tabla es la única garantía real, así que se
+ * usa su violación como señal para reintentar.
+ */
+async function createWithUniqueSlug(
+  repo: ShorterRepository,
+  input: Omit<CreateShortLinkInput, 'slug'>,
+): Promise<string> {
+  for (let attempt = 1; attempt <= MAX_SLUG_INSERT_ATTEMPTS; attempt++) {
+    const slug = generateSlug();
+    const { error } = await repo.create({ ...input, slug });
+
+    if (!error) return slug;
+
+    if (!isUniqueViolation(error)) {
+      log.error('failed to create short link', { error });
+      throw new ApiError("SERVER_ERROR", "internal server error", { status: 500 });
+    }
+
+    log.warn('slug collision, retrying', { attempt, maxAttempts: MAX_SLUG_INSERT_ATTEMPTS });
+  }
+
+  log.error('exhausted slug attempts', { maxAttempts: MAX_SLUG_INSERT_ATTEMPTS });
+  throw new ApiError("SERVER_ERROR", "internal server error", { status: 500 });
+}

--- a/src/app/ui/(main)/auth/callback/route.ts
+++ b/src/app/ui/(main)/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
 import { createClient } from '@/lib/supabase/server';
 import { ROUTES } from '@/lib/routes';
 
@@ -35,7 +36,7 @@ export async function GET(request: NextRequest) {
   const { error } = await supabase.auth.exchangeCodeForSession(code);
 
   if (error) {
-    console.error('OAuth callback exchange failed:', error.message);
+    logger.error('oauth callback exchange failed', { module: 'auth/callback', error });
     return NextResponse.redirect(`${SITE_URL}/auth/login?error=oauth_callback`);
   }
 

--- a/src/features/auth/services/auth.services.ts
+++ b/src/features/auth/services/auth.services.ts
@@ -5,6 +5,9 @@ import type { EmailOtpType } from "@supabase/supabase-js";
 import { AuthenticationError, ProviderAuthenticationError, ValidationError } from "@/lib/api/errors";
 import { successResponse } from "@/lib/api/responses";
 import { REDIRECT_TO_COOKIE_NAME } from "@/constants";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ module: 'auth' });
 
 const schemaLogin = z.object({
   email: z.email(),
@@ -59,7 +62,7 @@ export async function handleLogin(request: NextRequest) {
       return response;
     }
 
-    console.error(error);
+    log.error('oauth sign-in failed', { error });
     throw new ProviderAuthenticationError();
   }
 
@@ -69,7 +72,7 @@ export async function handleLogin(request: NextRequest) {
   });
 
   if (error) {
-    console.error(error)
+    log.info('sign-in rejected', { error });
     throw new AuthenticationError();
   }
 
@@ -97,7 +100,7 @@ export async function handleRegister(request: NextRequest) {
     } });
 
   if (error) {
-    console.error(error)
+    log.error('sign-up failed', { error });
     throw new ProviderAuthenticationError();
   }
 
@@ -117,7 +120,7 @@ export async function handleConfirm(request: NextRequest) {
       token_hash,
     })
     if (error) {
-      console.error(error)
+      log.info('otp verification failed', { error });
     } else {
       const paramNext = request.nextUrl.searchParams.get("next");
       if(paramNext?.startsWith("/")) {

--- a/src/features/dashboard/actions/edit_link.actions.ts
+++ b/src/features/dashboard/actions/edit_link.actions.ts
@@ -2,6 +2,9 @@
 
 import { getUserRepository } from "@/infra/db/user.repository";
 import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ action: 'editLink' });
 
 const REGEX_ALIAS = /[^a-zA-Z0-9_\- /#]+/;
 
@@ -16,7 +19,7 @@ export async function editLinkAction(initialState: LinkState, formData: FormData
   const slug = initialState.slug;
 
   if(REGEX_ALIAS.test(alias) || !slug) {
-    console.log("Invalid alias format");
+    log.info('rejected alias', { slug });
     return { ...initialState, success: false };
   }
 
@@ -25,22 +28,22 @@ export async function editLinkAction(initialState: LinkState, formData: FormData
 
   const { data: { user } } = await supabase.auth.getUser();
   if(!user) {
-    console.log("No session found");
+    log.info('rejected alias change without session', { slug });
     return { ...initialState, success: false };
   }
 
   const { data: isOwner } = await userRepo.isOwner(user.id, slug);
   if(!isOwner) {
-    console.log("No owner found for slug");
+    log.warn('rejected alias change from non-owner', { slug, userId: user.id });
     return { ...initialState, success: false };
   }
   const { error } = await userRepo.changeAlias(slug, alias);
 
   if(error) {
-    console.log(error);
+    log.error('failed to change alias', { slug, error });
     return { ...initialState, success: false };
   }
 
-  console.log(`Link with slug: ${slug} has been updated with new alias: ${alias}`);
+  log.info('alias updated', { slug });
   return { ...initialState, alias, success: true };
 }

--- a/src/features/dashboard/helpers/stats.ts
+++ b/src/features/dashboard/helpers/stats.ts
@@ -9,6 +9,9 @@ import { UserDashboardStats } from "@/features/dashboard/services/getStats";
 dayjs.extend(utc);
 dayjs.extend(customParseFormat);
 
+/** Marcador mostrado en los KPI cuando todavía no hay datos suficientes. */
+export const NO_DATA = '-';
+
 export function calcUserStats(urls: UserUrlStats[], summary: UserDashboardStats['summary'], all_time: UserDashboardStats['all_time'], refererStats?: IRefererStat[]) {
   const stats = urls.reduce((filtered: ILinkStats[], item) => {
     if(item.stats) filtered.push(item.stats);
@@ -21,20 +24,22 @@ export function calcUserStats(urls: UserUrlStats[], summary: UserDashboardStats[
     stats: stats.find(item => item.slug === url.slug)
   }));
 
-  const week = fillDays(summary.stats, {
+  const week = fillDays(summary.stats ?? [], {
     startDate: dayjs(summary.date_start).toDate(),
     endDate: dayjs(summary.date_end).toDate(),
   });
 
   const traffic = calcRefererStats(refererStats || []);
 
+  // Una cuenta recién creada llega aquí sin clics: todos los rankings vienen
+  // vacíos y ningún acceso por índice puede asumir que existe el primer elemento.
   return {
     general: {
       totalLinks: urls.length,
       totalClicks: all_time.clicks,
-      clicksLast24h: summary.clicks_last_24h || '-',
-      topLink: statsByClicks[0]?.slug,
-      topCountry: all_time.top_countries[0].name,
+      clicksLast24h: summary.clicks_last_24h || NO_DATA,
+      topLink: statsByClicks[0]?.slug ?? NO_DATA,
+      topCountry: all_time.top_countries?.[0]?.name ?? NO_DATA,
     },
     statsByClicks,
     links,
@@ -111,10 +116,12 @@ function calcRefererStats(stats: IRefererStat[]) {
     }
   }
 
+  // Sin clics registrados el porcentaje no está definido: se deja en 0 en lugar
+  // de propagar un NaN hasta los gráficos.
   for (const key in referersCount) {
-    referersCount[key].value = Number.parseFloat(
-      ((referersCount[key].count / total) * 100).toFixed(2)
-    );
+    referersCount[key].value = total > 0
+      ? Number.parseFloat(((referersCount[key].count / total) * 100).toFixed(2))
+      : 0;
   }
 
   return referersCount;

--- a/src/features/dashboard/hooks/useUserDashboard.tsx
+++ b/src/features/dashboard/hooks/useUserDashboard.tsx
@@ -18,7 +18,6 @@ export const useUserDashboard = () => {
 
   const stats = useMemo(() => {
     if(!data) return null;
-    console.log("Calculating user stats...", data.urls);
     return calcUserStats(data.urls, data.summary, data.all_time, data.refererStats);
   }, [data]);
 

--- a/src/infra/db/db-errors.ts
+++ b/src/infra/db/db-errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Códigos de error de PostgreSQL relevantes para la aplicación.
+ * @see https://www.postgresql.org/docs/current/errcodes-appendix.html
+ */
+export const PG_ERROR = {
+  UNIQUE_VIOLATION: '23505',
+  FOREIGN_KEY_VIOLATION: '23503',
+  CHECK_VIOLATION: '23514',
+} as const;
+
+/**
+ * `true` si el error corresponde a la violación de un índice único.
+ *
+ * PostgREST propaga el código nativo de PostgreSQL en `error.code`, de modo que
+ * este predicado sirve tanto para errores del cliente de Supabase como para
+ * errores levantados por funciones RPC.
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  return hasPostgresCode(error, PG_ERROR.UNIQUE_VIOLATION);
+}
+
+function hasPostgresCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === code
+  );
+}

--- a/src/infra/db/shorter.repository.ts
+++ b/src/infra/db/shorter.repository.ts
@@ -1,31 +1,38 @@
 import { DbInstance } from "@/infra/db/supabase_service";
-import { ClientInfo, UrlExpires, UtmParams } from "@/lib/types";
+import { ClientInfo, UrlExpires, UtmValues } from "@/lib/types";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+// dayjs es un singleton: extender aquí garantiza que `.utc()` esté disponible
+// aunque este repositorio se importe sin pasar antes por una ruta que lo extienda.
+dayjs.extend(utc);
+
+export type CreateShortLinkInput = {
+  userId: string | null;
+  slug: string;
+  destination: string;
+  utm: Partial<UtmValues>;
+  domain: string;
+  expires?: UrlExpires;
+  client?: Partial<ClientInfo>;
+};
 
 export function getShorterRepository(db: DbInstance) {
   return {
-    async create(
-      uid: string | null,
-      slug: string,
-      url: string,
-      utm: Partial<UtmParams>,
-      domain: string,
-      expires?: UrlExpires,
-      client?: Partial<ClientInfo>,
-    ) {
+    async create({ userId, slug, destination, utm, domain, expires, client }: CreateShortLinkInput) {
       return db
         .from('short_links')
         .insert([
           {
             slug,
-            destination: url,
+            destination,
             utm_source: utm?.source ?? null,
             utm_medium: utm?.medium ?? null,
             utm_campaign: utm?.campaign ?? null,
             utm_term: utm?.term ?? null,
             utm_content: utm?.content ?? null,
             utm_id: utm?.id ?? null,
-            user_id: uid ?? null,
+            user_id: userId ?? null,
             ip_user: client?.ip ?? null,
             country_code_user: client?.countryCode ?? null,
             domain: domain ?? null,

--- a/src/infra/payments/billing.repository.ts
+++ b/src/infra/payments/billing.repository.ts
@@ -1,5 +1,5 @@
 import { getPayPalClient } from "@/lib/paypal";
-import { ApiResponse } from "@apimatic/core/src/coreInterfaces";
+import type { ApiResponse } from "@paypal/paypal-server-sdk";
 import { CreateSubscriptionRequestBody, SubscriptionResponseBody } from "@paypal/paypal-js";
 
 /**

--- a/src/infra/payments/catalogs.repository.ts
+++ b/src/infra/payments/catalogs.repository.ts
@@ -1,5 +1,5 @@
 import { getPayPalClient } from "@/lib/paypal";
-import { ApiResponse } from "@apimatic/core/src/coreInterfaces";
+import type { ApiResponse } from "@paypal/paypal-server-sdk";
 
 /**
  * PayPal Catalog and Products

--- a/src/lib/cache/ttl-cache.ts
+++ b/src/lib/cache/ttl-cache.ts
@@ -1,0 +1,65 @@
+/**
+ * Caché en memoria con expiración por entrada y cota superior de tamaño.
+ *
+ * Pensada para procesos serverless: vive lo que vive la instancia y nunca crece
+ * sin límite. No sustituye a un store compartido (Redis); su objetivo es evitar
+ * consultas repetidas dentro de una misma instancia.
+ */
+export class TtlCache<T> {
+  private readonly entries = new Map<string, { value: T; expiresAt: number }>();
+
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries = 5_000,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  get(key: string): T | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+
+    if (entry.expiresAt <= this.now()) {
+      this.entries.delete(key);
+      return undefined;
+    }
+
+    return entry.value;
+  }
+
+  set(key: string, value: T): void {
+    // Map conserva el orden de inserción: re-insertar mueve la clave al final,
+    // de modo que la evicción por tamaño descarta siempre la más antigua.
+    this.entries.delete(key);
+    this.entries.set(key, { value, expiresAt: this.now() + this.ttlMs });
+
+    if (this.entries.size > this.maxEntries) this.evictOldest();
+  }
+
+  /** Aplica `update` sobre el valor vigente. No revive entradas expiradas. */
+  update(key: string, update: (current: T) => T): void {
+    const current = this.get(key);
+    if (current === undefined) return;
+
+    // Conserva la expiración original: refrescarla dejaría a un cliente activo
+    // indefinidamente sobre un valor obsoleto.
+    const expiresAt = this.entries.get(key)!.expiresAt;
+    this.entries.set(key, { value: update(current), expiresAt });
+  }
+
+  delete(key: string): void {
+    this.entries.delete(key);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  private evictOldest(): void {
+    const oldest = this.entries.keys().next();
+    if (!oldest.done) this.entries.delete(oldest.value);
+  }
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,157 @@
+/**
+ * Logger estructurado sin dependencias.
+ *
+ * - En producción emite una línea JSON por evento, lista para ser indexada por
+ *   Vercel Log Drains, Datadog o cualquier colector que parsee stdout.
+ * - En desarrollo emite texto legible.
+ * - Redacta claves sensibles (tokens, cookies, credenciales, PII) en cualquier
+ *   nivel del contexto antes de serializar.
+ *
+ * Uso:
+ *   import { logger } from '@/lib/logger';
+ *   const log = logger.child({ route: 'api/shorten', requestId });
+ *   log.warn('slug collision', { attempt: 2 });
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'silent';
+
+export type LogContext = Record<string, unknown>;
+
+const LEVEL_WEIGHT: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  silent: 100,
+};
+
+const CONSOLE_METHOD = {
+  debug: 'debug',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+} as const satisfies Record<Exclude<LogLevel, 'silent'>, keyof Console>;
+
+/** Claves cuyo valor nunca debe llegar a los logs. */
+const SENSITIVE_KEY =
+  /^(?:password|pass|pwd|secret|client_secret|token|access_token|refresh_token|id_token|authorization|cookie|set-cookie|api_?key|session|credit_?card|ip|ip_user|email|email_address)$/i;
+
+const REDACTED = '[redacted]';
+
+/** Profundidad máxima al serializar para evitar ciclos y objetos gigantes. */
+const MAX_DEPTH = 4;
+const MAX_ARRAY_ITEMS = 20;
+const MAX_STRING_LENGTH = 2_000;
+
+function resolveLevel(): LogLevel {
+  const configured = process.env.LOG_LEVEL?.toLowerCase();
+  if (configured && configured in LEVEL_WEIGHT) {
+    return configured as LogLevel;
+  }
+  return process.env.NODE_ENV === 'production' ? 'info' : 'debug';
+}
+
+function serializeError(error: Error): LogContext {
+  const serialized: LogContext = {
+    name: error.name,
+    message: error.message,
+  };
+
+  if (error.stack) serialized.stack = error.stack;
+  if (error.cause !== undefined) serialized.cause = sanitize(error.cause, MAX_DEPTH - 1);
+
+  // Errores de Supabase/PostgREST y ApiError exponen `code`; es lo más útil para
+  // filtrar en el colector, así que se conserva siempre que exista.
+  const code = (error as { code?: unknown }).code;
+  if (typeof code === 'string' || typeof code === 'number') serialized.code = code;
+
+  return serialized;
+}
+
+function sanitize(value: unknown, depth = MAX_DEPTH): unknown {
+  if (value === null || value === undefined) return value;
+
+  if (value instanceof Error) return serializeError(value);
+
+  switch (typeof value) {
+    case 'string':
+      return value.length > MAX_STRING_LENGTH ? `${value.slice(0, MAX_STRING_LENGTH)}…` : value;
+    case 'number':
+      return Number.isFinite(value) ? value : String(value);
+    case 'bigint':
+      return value.toString();
+    case 'boolean':
+      return value;
+    case 'function':
+    case 'symbol':
+      return undefined;
+  }
+
+  if (depth <= 0) return '[truncated]';
+
+  if (Array.isArray(value)) {
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((item) => sanitize(item, depth - 1));
+    return value.length > MAX_ARRAY_ITEMS ? [...items, `… +${value.length - MAX_ARRAY_ITEMS}`] : items;
+  }
+
+  if (value instanceof Date) return value.toISOString();
+
+  if (typeof value === 'object') {
+    const output: LogContext = {};
+    for (const [key, entry] of Object.entries(value as LogContext)) {
+      output[key] = SENSITIVE_KEY.test(key) ? REDACTED : sanitize(entry, depth - 1);
+    }
+    return output;
+  }
+
+  return String(value);
+}
+
+class Logger {
+  private readonly bindings: LogContext;
+
+  constructor(bindings: LogContext = {}) {
+    this.bindings = bindings;
+  }
+
+  /** Devuelve un logger que añade `bindings` a cada evento que emita. */
+  child(bindings: LogContext): Logger {
+    return new Logger({ ...this.bindings, ...bindings });
+  }
+
+  debug(message: string, context?: LogContext): void {
+    this.emit('debug', message, context);
+  }
+
+  info(message: string, context?: LogContext): void {
+    this.emit('info', message, context);
+  }
+
+  warn(message: string, context?: LogContext): void {
+    this.emit('warn', message, context);
+  }
+
+  error(message: string, context?: LogContext): void {
+    this.emit('error', message, context);
+  }
+
+  private emit(level: Exclude<LogLevel, 'silent'>, message: string, context?: LogContext): void {
+    if (LEVEL_WEIGHT[level] < LEVEL_WEIGHT[resolveLevel()]) return;
+
+    const payload = sanitize({ ...this.bindings, ...context }) as LogContext;
+    const write = console[CONSOLE_METHOD[level]].bind(console);
+
+    if (process.env.NODE_ENV === 'production') {
+      write(JSON.stringify({ level, message, time: new Date().toISOString(), ...payload }));
+      return;
+    }
+
+    const hasContext = Object.keys(payload).length > 0;
+    if (hasContext) write(`[${level}] ${message}`, payload);
+    else write(`[${level}] ${message}`);
+  }
+}
+
+export const logger = new Logger();
+
+export type { Logger };

--- a/src/lib/short-links/destination.ts
+++ b/src/lib/short-links/destination.ts
@@ -1,0 +1,67 @@
+import { ALLOWED_PARAMS } from "@/lib/routes";
+import { PlanName, UtmParams, UtmValues } from "@/lib/types";
+import { safeDecodeURI } from "@/lib/utils/url";
+
+export type DestinationPlan = PlanName | 'freeAnonymous';
+
+/** Parámetros UTM soportados, en el orden en que se escriben en la URL. */
+export const UTM_KEYS = ['source', 'medium', 'campaign', 'term', 'content', 'id'] as const;
+
+const UTM_PREFIX = 'utm_';
+
+/**
+ * Normaliza un valor UTM al conjunto de caracteres seguro para una query string.
+ * Devuelve `null` cuando el valor está vacío o queda vacío tras limpiarlo.
+ */
+export function sanitizeUtmValue(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const sanitized = value.replaceAll(/[^a-zA-Z0-9-_]/g, '');
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+/**
+ * Construye la URL de destino aplicando los UTM permitidos por el plan.
+ *
+ * - Los valores explícitos de `utm` tienen prioridad sobre los que ya venían en
+ *   la URL original.
+ * - Los UTM no permitidos para el plan se eliminan.
+ * - **Cualquier otro parámetro de la URL se conserva intacto.**
+ */
+export function buildDestination(
+  url: string,
+  utm: Partial<UtmValues>,
+  plan: DestinationPlan,
+): { destination: string; utm: UtmValues } {
+  const destination = new URL(url);
+  const allowed = new Set<string>(ALLOWED_PARAMS[plan]);
+
+  const resolved = resolveUtm(destination, utm);
+
+  for (const key of UTM_KEYS) {
+    const param = `${UTM_PREFIX}${key}`;
+    const value = resolved[key];
+
+    if (value !== null && allowed.has(param)) destination.searchParams.set(param, value);
+    else destination.searchParams.delete(param);
+  }
+
+  // Un UTM desconocido (utm_ algo que no está en UTM_KEYS) tampoco debe llegar
+  // al destino: se elimina sobre una copia de las claves para no mutar mientras
+  // se itera el iterador vivo de `searchParams`.
+  for (const param of [...destination.searchParams.keys()]) {
+    if (param.startsWith(UTM_PREFIX) && !allowed.has(param)) destination.searchParams.delete(param);
+  }
+
+  return {
+    destination: safeDecodeURI(destination.toString()),
+    utm: resolved,
+  };
+}
+
+function resolveUtm(destination: URL, utm: Partial<UtmValues>): UtmValues {
+  return UTM_KEYS.reduce((resolved, key) => {
+    const explicit = sanitizeUtmValue(utm[key]);
+    resolved[key] = explicit ?? sanitizeUtmValue(destination.searchParams.get(`${UTM_PREFIX}${key}`));
+    return resolved;
+  }, {} as UtmValues) satisfies Record<keyof UtmParams, string | null>;
+}

--- a/src/lib/short-links/slug.ts
+++ b/src/lib/short-links/slug.ts
@@ -1,0 +1,40 @@
+import { nanoid } from "nanoid";
+import { isReservedSlug } from "@/lib/reserved-slugs";
+
+/** Longitud por defecto de los slugs autogenerados. */
+export const SLUG_SIZE = 7;
+
+/**
+ * Intentos máximos para obtener un slug que no choque con la denylist.
+ * Con 7 caracteres del alfabeto de nanoid el espacio es de ~3,5·10¹², así que
+ * agotar estos intentos implica un fallo real, no mala suerte.
+ */
+export const MAX_SLUG_GENERATION_ATTEMPTS = 25;
+
+/**
+ * Intentos máximos de inserción ante colisión de slug en base de datos.
+ * Cada reintento genera un slug nuevo, por lo que la probabilidad de agotarlos
+ * es despreciable salvo que la tabla esté cerca de saturar el espacio de claves.
+ */
+export const MAX_SLUG_INSERT_ATTEMPTS = 5;
+
+export class SlugGenerationError extends Error {
+  constructor(attempts: number) {
+    super(`could not generate a valid slug after ${attempts} attempts`);
+    this.name = 'SlugGenerationError';
+  }
+}
+
+/**
+ * Genera un slug aleatorio que no colisiona con ninguna ruta reservada.
+ *
+ * @throws {SlugGenerationError} si no encuentra un candidato válido.
+ */
+export function generateSlug(size: number = SLUG_SIZE, generate: (size: number) => string = nanoid): string {
+  for (let attempt = 0; attempt < MAX_SLUG_GENERATION_ATTEMPTS; attempt++) {
+    const candidate = generate(size).toLowerCase();
+    if (!isReservedSlug(candidate)) return candidate;
+  }
+
+  throw new SlugGenerationError(MAX_SLUG_GENERATION_ATTEMPTS);
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -11,6 +11,13 @@ export interface UtmParams {
   id: string;
 }
 
+/**
+ * UTM ya resueltos para un link: todas las claves están presentes y valen `null`
+ * cuando no se informaron. Modela lo que realmente se persiste, a diferencia de
+ * `UtmParams`, que describe la forma de los valores cuando existen.
+ */
+export type UtmValues = { [Key in keyof UtmParams]: string | null };
+
 export interface ClientInfo {
   ip: string | null;
   countryCode: string | null;

--- a/src/lib/utils/rate-limits.ts
+++ b/src/lib/utils/rate-limits.ts
@@ -1,41 +1,179 @@
 import { ShorterRepository } from "@/infra/db/shorter.repository";
-import { UserRepository } from "@/infra/db/user.repository";
 import { PlanName } from "@/lib/types";
+import { TtlCache } from "@/lib/cache/ttl-cache";
+import { logger } from "@/lib/logger";
 
-export type RateLimitConfig = { [Key in PlanName]: number } & { freeAnonymous: number };
+export type RateLimitPlan = PlanName | 'freeAnonymous';
 
-export const RATE_LIMITS: RateLimitConfig = {
+/** Links que cada plan puede crear por mes. */
+export const RATE_LIMITS: Record<RateLimitPlan, number> = {
   freeAnonymous: 5,
   free: 50,
   basic: 1000,
   pro: 10000,
 };
 
-export async function checkRateLimit(
-  user_id: string | null,
-  user_plan: string | null,
-  ip: string,
-  shorterRepo: ShorterRepository,
-): Promise<{ allowed: boolean; message?: string }> {
-  if (!user_id) {
-    const { count } = await shorterRepo.countLinksByIpInLastMonth(ip);
-    if (count !== null && count >= RATE_LIMITS.freeAnonymous) {
-      return {
-        allowed: false,
-        message: `Límite alcanzado: ${RATE_LIMITS.freeAnonymous} links/mes. Inicia sesión para más.`
-      };
-    }
-  } else if (user_plan && user_plan in RATE_LIMITS) {
-    const { count } = await shorterRepo.countLinksByUserInLastMonth(user_id);
-    // @ts-expect-error plan es una key de RATE_LIMITS, pero TypeScript no lo infiere correctamente
-    if(count !== null && count >= RATE_LIMITS[user_plan]) {
-      return {
-        allowed: false,
-        // @ts-expect-error plan es una key de RATE_LIMITS, pero TypeScript no lo infiere correctamente
-        message: `Límite alcanzado para el plan ${user_plan}: ${RATE_LIMITS[user_plan]} links/mes. Considera actualizar tu plan.`
-      };
-    }
+/**
+ * Plan aplicado a un usuario autenticado cuyo plan no se pudo determinar
+ * (metadata del JWT ausente o con un valor desconocido). Se elige el más
+ * restrictivo de los planes autenticados para no dejar la cuota abierta.
+ */
+const FALLBACK_AUTHENTICATED_PLAN: PlanName = 'free';
+
+/** Bucket para peticiones anónimas sin IP atribuible (p. ej. en local). */
+const UNKNOWN_CLIENT = 'unknown';
+
+/**
+ * Vigencia del consumo cacheado. Corto a propósito: el contador vive por
+ * instancia, así que una ventana breve acota cuánto puede desviarse del valor
+ * real cuando hay varias instancias sirviendo tráfico en paralelo.
+ */
+const USAGE_TTL_MS = 60_000;
+
+const log = logger.child({ module: 'rate-limits' });
+
+/**
+ * Contador de consumo. La implementación por defecto vive en memoria; sustituir
+ * esta interfaz por una respaldada en Redis es el único cambio necesario para
+ * tener conteo exacto y compartido entre instancias.
+ */
+export interface UsageStore {
+  get(key: string): number | undefined;
+  set(key: string, used: number): void;
+  increment(key: string, delta?: number): void;
+}
+
+export class MemoryUsageStore implements UsageStore {
+  private readonly cache: TtlCache<number>;
+
+  constructor(ttlMs: number = USAGE_TTL_MS, maxEntries?: number) {
+    this.cache = new TtlCache<number>(ttlMs, maxEntries);
   }
 
-  return { allowed: true };
+  get(key: string): number | undefined {
+    return this.cache.get(key);
+  }
+
+  set(key: string, used: number): void {
+    this.cache.set(key, used);
+  }
+
+  increment(key: string, delta = 1): void {
+    this.cache.update(key, (current) => current + delta);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+export const defaultUsageStore = new MemoryUsageStore();
+
+export type RateLimitResult = {
+  allowed: boolean;
+  /** Clave del bucket; necesaria para registrar el consumo tras crear el link. */
+  key: string;
+  plan: RateLimitPlan;
+  limit: number;
+  used: number;
+  remaining: number;
+};
+
+export type RateLimitInput = {
+  userId: string | null;
+  plan: PlanName | null;
+  ip: string | null;
+  repo: ShorterRepository;
+  store?: UsageStore;
+};
+
+export function resolveRateLimitPlan(userId: string | null, plan: PlanName | null): RateLimitPlan {
+  if (!userId) return 'freeAnonymous';
+  if (plan !== null && Object.hasOwn(RATE_LIMITS, plan)) return plan;
+
+  log.warn('unknown plan for authenticated user, applying fallback', {
+    plan,
+    fallback: FALLBACK_AUTHENTICATED_PLAN,
+  });
+  return FALLBACK_AUTHENTICATED_PLAN;
+}
+
+export function usageKey(userId: string | null, ip: string | null): string {
+  return userId ? `user:${userId}` : `ip:${ip ?? UNKNOWN_CLIENT}`;
+}
+
+/**
+ * Comprueba si el cliente puede crear otro link.
+ *
+ * El consumo se resuelve desde la caché cuando está disponible; sólo se consulta
+ * la base de datos en el primer acceso de cada ventana, lo que evita un COUNT
+ * por cada petición.
+ */
+export async function checkRateLimit({
+  userId,
+  plan,
+  ip,
+  repo,
+  store = defaultUsageStore,
+}: RateLimitInput): Promise<RateLimitResult> {
+  const effectivePlan = resolveRateLimitPlan(userId, plan);
+  const limit = RATE_LIMITS[effectivePlan];
+  const key = usageKey(userId, ip);
+
+  const cached = store.get(key);
+  const used = cached ?? (await loadUsage({ userId, ip, repo }));
+
+  if (used === null) {
+    // No se pudo medir el consumo. Se permite la petición: el insert posterior
+    // es la barrera real y fallará igualmente si la base de datos no responde.
+    return { allowed: true, key, plan: effectivePlan, limit, used: 0, remaining: limit };
+  }
+
+  if (cached === undefined) store.set(key, used);
+
+  return {
+    allowed: used < limit,
+    key,
+    plan: effectivePlan,
+    limit,
+    used,
+    remaining: Math.max(0, limit - used),
+  };
+}
+
+/** Registra un link creado para que la caché no quede por debajo del consumo real. */
+export function recordRateLimitUsage(
+  result: Pick<RateLimitResult, 'key'>,
+  store: UsageStore = defaultUsageStore,
+): void {
+  store.increment(result.key);
+}
+
+async function loadUsage({
+  userId,
+  ip,
+  repo,
+}: Pick<RateLimitInput, 'userId' | 'ip' | 'repo'>): Promise<number | null> {
+  if (userId) {
+    const { count, error } = await repo.countLinksByUserInLastMonth(userId);
+    if (error) {
+      log.error('failed to count links by user', { error });
+      return null;
+    }
+    return count ?? 0;
+  }
+
+  if (ip) {
+    const { count, error } = await repo.countLinksByIpInLastMonth(ip);
+    if (error) {
+      log.error('failed to count links by ip', { error });
+      return null;
+    }
+    return count ?? 0;
+  }
+
+  // Sin usuario ni IP no hay nada que consultar en base de datos: el consumo se
+  // contabiliza únicamente en memoria para esta instancia.
+  log.warn('anonymous request without a resolvable client ip');
+  return 0;
 }

--- a/src/lib/utils/retry.ts
+++ b/src/lib/utils/retry.ts
@@ -1,10 +1,16 @@
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ module: 'retry' });
+
 /**
  * Reintenta ejecutar una función asíncrona hasta N veces.
  *
  * @param fn - Función async a ejecutar (debe lanzar error si falla)
  * @param retries - Número máximo de intentos (por defecto 3)
  * @param delayMs - Retraso inicial entre intentos (por defecto 100 ms)
- * @param backoff - Multiplicador de incremento del delay (por defecto 0)
+ * @param backoff - Multiplicador aplicado al retraso tras cada intento fallido.
+ *                  Por defecto 2 (backoff exponencial); usar 1 para mantener un
+ *                  intervalo constante.
  * @returns El valor retornado por la función si tiene éxito
  * @throws El último error si todos los intentos fallan
  */
@@ -12,31 +18,33 @@ export async function retry<T>(
   fn: () => Promise<T>,
   retries: number = 3,
   delayMs: number = 100,
-  backoff: number = 0
+  backoff: number = 2
 ): Promise<T> {
   let attempt = 0;
   let lastError: unknown;
+  let currentDelay = delayMs;
 
   while (attempt < retries) {
     try {
-      return await fn(); // Intenta ejecutar la función
+      return await fn();
     } catch (error) {
       lastError = error;
       attempt++;
 
       if (attempt >= retries) break;
 
-      console.warn(
-        `Intento ${attempt} fallido. Reintentando en ${delayMs}ms...`,
-        error
-      );
+      log.warn('attempt failed, retrying', { attempt, retries, delayMs: currentDelay, error });
 
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-      delayMs *= backoff; // Incrementa el delay (backoff exponencial)
+      await sleep(currentDelay);
+      currentDelay *= backoff;
     }
   }
 
   throw lastError;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export async function retryWithCancel<T>(

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,0 +1,14 @@
+/**
+ * `decodeURI` que no lanza ante secuencias porcentuales inválidas.
+ *
+ * Una URL como `https://example.com/100%discount` es aceptada por `new URL()`
+ * pero hace que `decodeURI` lance `URIError`. Sin esta guarda, un destino con un
+ * `%` suelto convierte la petición en un 500.
+ */
+export function safeDecodeURI(value: string): string {
+  try {
+    return decodeURI(value);
+  } catch {
+    return value;
+  }
+}


### PR DESCRIPTION
Large refactor and test additions: adds comprehensive Jest tests and mocks (nanoid, next-intl-server); implements a structured logger, TTL in-memory cache, and an in-memory UsageStore for rate limits with caching; introduces safeDecodeURI, UTM destination builder, and a slug generator with collision-retry logic and PG error helpers. Refactors shorter.repository.create signature and /api/shorten and /[short] routes to use new modules (domain checks, retries, expiry for anonymous links, record rate usage). Also adds ESLint, updates jest config/setup, CSP headers in next.config, README and package.json scripts.