### PR TITLE
Add link expiry logic, status pages & tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,9 @@ Cada una de estas costó un ciclo de trabajo. Leerlas antes de explorar el repo.
   «sin referencias».
 - `service.repository.ts` (singular) y `services.repository.ts` (plural, lo usa el carrito) son
   ficheros distintos con nombres casi idénticos.
+- En PostgreSQL toda función nace con `EXECUTE` concedido a **PUBLIC**, y `anon` lo hereda por ahí:
+  `revoke execute ... from anon` no le quita nada. Hay que revocar a `public`, y eso también se lo
+  quita a `service_role`, así que después toca devolvérselo explícitamente. Verificado en PG 16.
 - En Jest, `@supabase/*` se publica como ESM sin transformar. Los tests **mockean en la frontera de
   datos** (`@/data/dto/user-dto`, los repositorios) en lugar de importar el cliente real. `nanoid`
   está mapeado a `__mocks__/nanoid.js` por el mismo motivo.
@@ -96,9 +99,10 @@ Auditoría del 2026-08-09 (`scripts/sql/auditoria.sql`, resultados reales, no su
   Recordatorio de por qué importaba: la resolución de enlaces y las estadísticas usan service role,
   así que ninguna lectura pública era necesaria, y mientras existieron esas políticas el arreglo de
   autorización de `/api/dashboard/stats/[slug]` no protegía nada.
-- **ABIERTO — `anon` y `authenticated` tienen DELETE, INSERT, REFERENCES, SELECT, TRIGGER, TRUNCATE
-  y UPDATE sobre todas las tablas de `public`** (grant por defecto de Supabase). RLS lo contiene
-  hoy, pero TRUNCATE no está sujeto a RLS y basta desactivarla en una tabla para exponerla.
+- **CERRADO el 2026-08-09 — GRANT ALL por defecto.** Se revocó todo sobre `public` para `anon` y
+  `authenticated`, dejando sólo `grant select, update on public.short_links to authenticated`. Al
+  hacerlo, cualquier consulta desde el navegador o con la sesión del usuario sobre otra tabla falla
+  con «permission denied», que a diferencia de RLS es un error duro y no un filtro de filas.
 - **ABIERTO — `public.get_page_traffic` es SECURITY DEFINER y anon puede ejecutarla.** Permite pedir
   el tráfico de cualquier slug por RPC. `security.insert_blocked_url` también está abierta a anon.
 - **RESUELTO por diseño previo**: `short_links_pkey` es `PRIMARY KEY (slug)`, así que el índice
@@ -110,11 +114,19 @@ Auditoría del 2026-08-09 (`scripts/sql/auditoria.sql`, resultados reales, no su
 - Volumen: `short_links` 2 636 filas, `history_clicks` 35 194 (11 MB). Las consultas de cuota hacen
   Seq Scan en 0,45 ms; los índices `(user_id, created_at)` e `(ip_user, created_at)` son previsión,
   no urgencia.
+- Resolución de `/[short]`: la decisión vive en `lib/short-links/resolve-link-state.ts` (función
+  pura, con tests) y las páginas en `lib/short-links/status-page.ts`. Un enlace caducado responde
+  **410 Gone** con pantalla propia que invita a registrarse; uno inexistente, 404. Por eso
+  `getBySlug` ya no filtra por `status`: filtrarlo hacía indistinguibles ambos casos tras la
+  primera visita.
 - 1 904 enlaces caducados siguen con `status = true` (sólo se desactivan al visitarlos). 315 links
   tienen desfase entre `short_links.clicks` y `short_links_stats.total_clicks`.
-- `short_links_stats` tiene RLS sin políticas, así que el embebido `stats:short_links_stats(...)`
-  de `getStatsUserUrls` siempre vuelve vacío para el rol `authenticated`. Nada lo consume desde que
-  `calcUserStats` pasa `urls` directamente: ese trozo del select se puede quitar.
+- Esquema `security` (auditado el 2026-08-09): cuatro tablas — `blocked_url`,
+  `blocklist_url_phishing_active`, `cached_blocked_url`, `whitelist_url` — todas con RLS y una
+  política, y **sin ningún grant a `anon` ni `authenticated`**. Está limpio.
+- `getStatsUserUrls` ya **no** embebe `stats:short_links_stats(...)`. Tras revocar los grants, ese
+  embebido pasaba de devolver null a fallar con «permission denied». No reintroducirlo sin conceder
+  antes el SELECT sobre esa tabla.
 - Hipótesis a confirmar: la edición de alias no funcionaba antes del 2026-08-09, porque
   `changeAlias` hace UPDATE con la sesión del usuario y no existía política de UPDATE; PostgREST
   devuelve 0 filas sin error. `short_links_update_own` debería haberlo desbloqueado.

--- a/__tests__/lib/short-links/resolve-link-state.test.ts
+++ b/__tests__/lib/short-links/resolve-link-state.test.ts
@@ -1,0 +1,57 @@
+import { resolveLinkState, type LinkRow } from '@/lib/short-links/resolve-link-state';
+
+const NOW = new Date('2026-08-09T12:00:00.000Z');
+
+const link = (overrides: Partial<LinkRow> = {}): LinkRow => ({
+  destination: 'https://example.com',
+  expires_at: null,
+  status: true,
+  ...overrides,
+});
+
+describe('resolveLinkState', () => {
+  it('redirects an active link without expiry', () => {
+    expect(resolveLinkState(link(), NOW)).toBe('active');
+  });
+
+  it('redirects a link whose expiry is still in the future', () => {
+    expect(resolveLinkState(link({ expires_at: '2026-12-01T00:00:00.000Z' }), NOW)).toBe('active');
+  });
+
+  it('treats a missing row as not found', () => {
+    expect(resolveLinkState(null, NOW)).toBe('not-found');
+  });
+
+  it('treats a row without destination as not found', () => {
+    expect(resolveLinkState(link({ destination: null }), NOW)).toBe('not-found');
+  });
+
+  it('marks a link past its expiry as expired', () => {
+    expect(resolveLinkState(link({ expires_at: '2026-08-01T00:00:00.000Z' }), NOW)).toBe('expired');
+  });
+
+  it('expires exactly at the boundary', () => {
+    expect(resolveLinkState(link({ expires_at: NOW.toISOString() }), NOW)).toBe('expired');
+  });
+
+  // Tras la primera visita el resolver escribe status = false. La fila sigue
+  // ahí, y hay que reconocerla como caducada en vez de como inexistente.
+  it('keeps recognising an already deactivated expired link', () => {
+    const deactivated = link({ expires_at: '2026-08-01T00:00:00.000Z', status: false });
+    expect(resolveLinkState(deactivated, NOW)).toBe('expired');
+  });
+
+  // Sin fecha de caducidad no sabemos por qué se desactivó, así que no procede
+  // insinuar que el slug existió.
+  it('hides a deactivated link that never had an expiry', () => {
+    expect(resolveLinkState(link({ status: false }), NOW)).toBe('not-found');
+  });
+
+  it('ignores an unparseable expiry instead of throwing', () => {
+    expect(resolveLinkState(link({ expires_at: 'no es una fecha' }), NOW)).toBe('active');
+  });
+
+  it('defaults to the current time when none is given', () => {
+    expect(resolveLinkState(link({ expires_at: '2000-01-01T00:00:00.000Z' }))).toBe('expired');
+  });
+});

--- a/__tests__/lib/short-links/status-page.test.ts
+++ b/__tests__/lib/short-links/status-page.test.ts
@@ -1,0 +1,64 @@
+import { renderStatusPage } from '@/lib/short-links/status-page';
+
+const base = {
+  lang: 'es',
+  metaTitle: 'Enlace caducado | iny.one',
+  headline: 'Este enlace ha caducado',
+  subtitle: 'Los enlaces creados sin cuenta caducan a los 180 días.',
+  footer: 'Acortador de URLs con UTM',
+  actions: [
+    { href: '/auth/register', label: 'Crear cuenta gratis', variant: 'primary' as const },
+    { href: '/', label: 'Acortar otro enlace', variant: 'soft' as const },
+  ],
+};
+
+describe('renderStatusPage', () => {
+  it('renders the copy and the language', () => {
+    const html = renderStatusPage(base);
+
+    expect(html).toContain('<html lang="es">');
+    expect(html).toContain('<title>Enlace caducado | iny.one</title>');
+    expect(html).toContain('Este enlace ha caducado');
+    expect(html).toContain('Los enlaces creados sin cuenta caducan a los 180 días.');
+  });
+
+  it('always asks not to be indexed', () => {
+    expect(renderStatusPage(base)).toContain('<meta name="robots" content="noindex" />');
+  });
+
+  it('renders every action with its variant', () => {
+    const html = renderStatusPage(base);
+
+    expect(html).toContain('<a class="btn primary" href="/auth/register">Crear cuenta gratis</a>');
+    expect(html).toContain('<a class="btn soft" href="/">Acortar otro enlace</a>');
+  });
+
+  it('renders a plain action and its rel attribute', () => {
+    const html = renderStatusPage({
+      ...base,
+      actions: [{ href: 'javascript:history.back()', label: 'Atrás', rel: 'nofollow' }],
+    });
+
+    expect(html).toContain('class="btn"');
+    expect(html).toContain('rel="nofollow"');
+  });
+
+  // Los textos vienen de las traducciones, pero se interpolan en HTML crudo.
+  it('escapes text so it cannot inject markup', () => {
+    const html = renderStatusPage({
+      ...base,
+      headline: '<script>alert(1)</script>',
+      subtitle: 'comillas " y ampersand &',
+    });
+
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&quot;');
+    expect(html).toContain('&amp;');
+  });
+
+  it('picks the icon requested', () => {
+    expect(renderStatusPage({ ...base, icon: 'clock' })).toContain('<circle cx="12" cy="12" r="10">');
+    expect(renderStatusPage({ ...base, icon: 'link' })).toContain('M10 13a5 5 0');
+  });
+});

--- a/data/lang/en.d.json.ts
+++ b/data/lang/en.d.json.ts
@@ -58,7 +58,9 @@ declare const messages: {
     "qrShow": "Show QR code",
     "qrHide": "Hide QR code",
     "qrDownload": "Download PNG",
-    "qrAlt": "QR code for your short link"
+    "qrAlt": "QR code for your short link",
+    "anonymousNotice": "Links created without an account expire after {days, number} days.",
+    "anonymousNoticeCta": "Create a free account"
   },
   "HomeContent": {
     "howTitle": "How to shorten a URL with UTM tracking",
@@ -221,6 +223,14 @@ declare const messages: {
       "saturday": "Saturday",
       "sunday": "Sunday"
     }
+  },
+  "linkExpired": {
+    "metaTitle": "Link expired | iny.one",
+    "title": "This link has expired",
+    "subtitle": "Links created without an account expire after 180 days. Create a free account and yours will never expire — plus you get click analytics for every link.",
+    "cta": "Create a free account",
+    "goHome": "Shorten another link",
+    "footer": "URL shortener with UTM"
   }
 };
 export default messages;

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -55,7 +55,9 @@
     "qrShow": "Show QR code",
     "qrHide": "Hide QR code",
     "qrDownload": "Download PNG",
-    "qrAlt": "QR code for your short link"
+    "qrAlt": "QR code for your short link",
+    "anonymousNotice": "Links created without an account expire after {days, number} days.",
+    "anonymousNoticeCta": "Create a free account"
   },
   "HomeContent": {
     "howTitle": "How to shorten a URL with UTM tracking",
@@ -218,5 +220,13 @@
       "saturday": "Saturday",
       "sunday": "Sunday"
     }
+  },
+  "linkExpired": {
+    "metaTitle": "Link expired | iny.one",
+    "title": "This link has expired",
+    "subtitle": "Links created without an account expire after 180 days. Create a free account and yours will never expire — plus you get click analytics for every link.",
+    "cta": "Create a free account",
+    "goHome": "Shorten another link",
+    "footer": "URL shortener with UTM"
   }
 }

--- a/data/lang/es.json
+++ b/data/lang/es.json
@@ -1,7 +1,7 @@
 {
   "404": {
-    "metaTitle": "404 – Page Not Found | iny.one",
-    "metaDescription": "The page you are looking for does not exist. Check the URL or return to the homepage.",
+    "metaTitle": "404 – Página no encontrada | iny.one",
+    "metaDescription": "La página que buscas no existe. Revisa la URL o vuelve al inicio.",
     "title": "404",
     "subtitle": "La página o el enlace no existe.",
     "goBack": "Atrás",
@@ -55,7 +55,9 @@
     "qrShow": "Mostrar código QR",
     "qrHide": "Ocultar código QR",
     "qrDownload": "Descargar PNG",
-    "qrAlt": "Código QR de tu enlace corto"
+    "qrAlt": "Código QR de tu enlace corto",
+    "anonymousNotice": "Los enlaces creados sin cuenta caducan a los {days, number} días.",
+    "anonymousNoticeCta": "Crea una cuenta gratis"
   },
   "HomeContent": {
     "howTitle": "Cómo acortar una URL con seguimiento UTM",
@@ -218,5 +220,13 @@
       "saturday": "Sabado",
       "sunday": "Domingo"
     }
+  },
+  "linkExpired": {
+    "metaTitle": "Enlace caducado | iny.one",
+    "title": "Este enlace ha caducado",
+    "subtitle": "Los enlaces creados sin cuenta caducan a los 180 días. Crea una cuenta gratis y los tuyos no caducarán, además de tener estadísticas de clics de cada enlace.",
+    "cta": "Crear cuenta gratis",
+    "goHome": "Acortar otro enlace",
+    "footer": "Acortador de URLs con UTM"
   }
 }

--- a/scripts/sql/remediacion.sql
+++ b/scripts/sql/remediacion.sql
@@ -96,23 +96,76 @@ grant select, update on public.short_links to authenticated;
 -- =============================================================================
 -- PASO 3 — Funciones invocables por anon
 -- =============================================================================
+-- OJO CON EL PRIVILEGIO HEREDADO DE `PUBLIC`.
+-- En PostgreSQL toda función nace con EXECUTE concedido a `PUBLIC`, y `anon` lo
+-- hereda por ahí. Comprobado en PostgreSQL 16:
+--
+--   revoke execute ... from anon, authenticated;   -> anon SIGUE pudiendo (true)
+--   revoke execute ... from public;                -> anon deja de poder, pero
+--                                                     service_role TAMBIÉN lo pierde
+--
+-- Por eso cada bloque revoca a `public` y devuelve el permiso a `service_role`
+-- de forma explícita. Sin ese grant final se rompe lo que sí usa la aplicación:
+-- get_page_traffic alimenta el gráfico «Source Traffic» del dashboard e
+-- insert_blocked_url la usan los scripts de mantenimiento de la denylist.
 
--- get_page_traffic es SECURITY DEFINER y anon puede ejecutarla: permite pedir
--- el tráfico por referer de cualquier lista de slugs llamando al RPC
--- directamente, sin pasar por la aplicación. La llama el dashboard con service
--- role, así que no necesita estar abierta.
-revoke execute on function public.get_page_traffic(text[]) from anon, authenticated;
 
--- insert_blocked_url escribe en la denylist de dominios. Abierta a anon permite
--- inyectar dominios y bloquear destinos legítimos. Sólo la usan los scripts de
--- mantenimiento, que se autentican con service role.
-revoke execute on function security.insert_blocked_url(text[]) from anon, authenticated;
+-- 3.1 Foto previa. Anotar los valores para poder comparar.
+select n.nspname || '.' || p.proname as funcion,
+       case when p.prosecdef then 'DEFINER' else 'INVOKER' end as seguridad,
+       has_function_privilege('anon', p.oid, 'EXECUTE') as anon,
+       has_function_privilege('authenticated', p.oid, 'EXECUTE') as auth,
+       has_function_privilege('service_role', p.oid, 'EXECUTE') as service_role
+from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+where n.nspname in ('public','security')
+  and p.proname in ('get_page_traffic','insert_blocked_url','is_domain_secure',
+                    'get_dashboard_stats_summary','get_page_clicks_between_dates','authorize')
+order by funcion;
 
--- REVISAR ANTES DE EJECUTAR: `authorize` es el patrón RBAC de Supabase y suele
--- invocarse desde dentro de políticas. Si alguna política la usa, revocarle el
--- EXECUTE al rol que evalúa la política rompe esa consulta. Comprobar primero:
---   select policyname, qual from pg_policies where qual ilike '%authorize%';
--- revoke execute on function public.authorize(app_permission) from anon;
+
+-- 3.2 get_page_traffic: es SECURITY DEFINER, así que ejecutarla salta la RLS y
+--     devuelve el tráfico de cualquier slug que se le pase.
+revoke execute on function public.get_page_traffic(text[]) from public, anon, authenticated;
+grant  execute on function public.get_page_traffic(text[]) to service_role;
+
+
+-- 3.3 insert_blocked_url: escribe en la denylist de dominios. Abierta permitiría
+--     inyectar dominios y bloquear destinos legítimos.
+revoke execute on function security.insert_blocked_url(text[]) from public, anon, authenticated;
+grant  execute on function security.insert_blocked_url(text[]) to service_role;
+
+
+-- 3.4 Repetir la consulta de 3.1.
+--     ESPERADO: anon = false, auth = false, service_role = true en ambas.
+--     Si service_role saliera false, ejecutar el grant correspondiente otra vez.
+
+
+-- 3.5 Comprobar el dashboard: el gráfico «Source Traffic» debe seguir pintándose.
+--     Es lo único que consume get_page_traffic.
+
+
+-- -----------------------------------------------------------------------------
+-- Opcional: mismo patrón para las otras dos, de menor riesgo
+-- -----------------------------------------------------------------------------
+-- Ambas son SECURITY INVOKER, así que hoy anon ya no obtiene nada al llamarlas
+-- (las tablas que leen le están denegadas). Cerrarlas es higiene, no urgencia.
+--
+-- revoke execute on function public.get_dashboard_stats_summary(text[], timestamp, timestamp, text) from public, anon, authenticated;
+-- grant  execute on function public.get_dashboard_stats_summary(text[], timestamp, timestamp, text) to service_role;
+--
+-- revoke execute on function security.is_domain_secure(text) from public, anon, authenticated;
+-- grant  execute on function security.is_domain_secure(text) to service_role;
+
+
+-- -----------------------------------------------------------------------------
+-- NO tocar `authorize` sin comprobar antes
+-- -----------------------------------------------------------------------------
+-- Es el patrón RBAC de Supabase y suele invocarse desde dentro de políticas. Si
+-- alguna la usa, quitarle el EXECUTE al rol que evalúa la política rompe esa
+-- consulta. Comprobar primero:
+--   select policyname, qual, with_check from pg_policies
+--   where qual ilike '%authorize%' or with_check ilike '%authorize%';
+-- Sólo si no devuelve nada tiene sentido revocarla.
 
 
 -- =============================================================================

--- a/src/app/[short]/route.tsx
+++ b/src/app/[short]/route.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs';
 import { headers as getHeaders } from 'next/headers';
 import { after, NextRequest, NextResponse, userAgentFromString } from 'next/server';
 import { getGeoLocation } from '@/lib/utils/geolocation';
@@ -8,6 +7,8 @@ import { ROUTES } from "@/lib/routes";
 import { getTranslations, getLocale } from "next-intl/server";
 import { isReservedSlug, normalizeSlug } from '@/lib/reserved-slugs';
 import { safeDecodeURI } from '@/lib/utils/url';
+import { resolveLinkState } from '@/lib/short-links/resolve-link-state';
+import { renderStatusPage } from '@/lib/short-links/status-page';
 import { logger } from '@/lib/logger';
 
 const log = logger.child({ route: '[short]' });
@@ -16,13 +17,11 @@ export async function GET(request: NextRequest, ctx: RouteContext<'/[short]'>) {
   const { short } = await ctx.params;
   if (!short || short.length <= 0) return render404();
 
-  const reservedCheck = normalizeSlug(short);
-  if (isReservedSlug(reservedCheck)) {
+  if (isReservedSlug(normalizeSlug(short))) {
     return render404();
   }
 
   const shorterRepo = getShorterRepository(supabase_service);
-
   const { data, error } = await shorterRepo.getBySlug(short);
 
   if (error) {
@@ -30,17 +29,18 @@ export async function GET(request: NextRequest, ctx: RouteContext<'/[short]'>) {
     return render404();
   }
 
-  if (!data?.destination) return render404();
+  const state = resolveLinkState(data);
 
-  if (data.expires_at) {
-    const now = dayjs();
-    const expiresAt = dayjs(data.expires_at);
-
-    if (expiresAt.isValid() && expiresAt.isBefore(now, 'hour')) {
+  if (state === 'expired') {
+    // Sólo la primera visita tras caducar necesita escribir; después `status`
+    // ya es false y repetirlo sería un write por cada visita.
+    if (data?.status === true) {
       await shorterRepo.setStatus(short, false);
-      return render404();
     }
+    return renderExpired();
   }
+
+  if (state === 'not-found') return render404();
 
   const headerList = await getHeaders();
 
@@ -59,222 +59,60 @@ export async function GET(request: NextRequest, ctx: RouteContext<'/[short]'>) {
 
   // safeDecodeURI: un destino con un `%` suelto haría que `decodeURI` lance
   // URIError y convertiría cada visita al link en un 500.
-  const destination = safeDecodeURI(data.destination);
+  const destination = safeDecodeURI(data!.destination!);
   const response = NextResponse.redirect(destination, 307);
   response.headers.set('X-Robots-Tag', 'noindex');
   return response;
 }
 
+const HTML_HEADERS = {
+  "content-type": "text/html; charset=utf-8",
+  "cache-control": "no-store",
+  "X-Robots-Tag": "noindex",
+} as const;
+
 async function render404() {
-  const html = await get404();
-  return new NextResponse(html, {
-    status: 404,
-    headers: {
-      "content-type": "text/html; charset=utf-8",
-      "cache-control": "no-store",
-      "X-Robots-Tag": "noindex"
-    },
+  const [locale, t] = await Promise.all([getLocale(), getTranslations('404')]);
+
+  const html = renderStatusPage({
+    lang: locale,
+    metaTitle: t('metaTitle'),
+    headline: t('title'),
+    subtitle: t('subtitle'),
+    footer: t('footer'),
+    icon: 'link',
+    actions: [
+      { href: ROUTES.HOME, label: t('goHome'), variant: 'primary' },
+      { href: ROUTES.DASHBOARD, label: t('goDashboard'), variant: 'soft' },
+      { href: 'javascript:history.back()', label: t('goBack'), rel: 'nofollow' },
+    ],
   });
+
+  return new NextResponse(html, { status: 404, headers: HTML_HEADERS });
 }
 
-async function get404() {
-  const locale = await getLocale();
-  const t = await getTranslations('404');
+/**
+ * Un enlace que caducó existió: responde 410 Gone, que le dice a los buscadores
+ * que lo desindexen en lugar de reintentarlo como haría un 404.
+ *
+ * Es además la única página del sitio que recibe tráfico de alguien que ya
+ * conocía un enlace de iny.one, así que la acción principal invita a registrarse.
+ */
+async function renderExpired() {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations('linkExpired')]);
 
-  const texts = {
-    head: {
-      lang: locale,
-      title: t('metaTitle'),
-      description: t('metaDescription'),
-    },
-    title: t('title'),
+  const html = renderStatusPage({
+    lang: locale,
+    metaTitle: t('metaTitle'),
+    headline: t('title'),
     subtitle: t('subtitle'),
-    goBack: t('goBack'),
-    goHome: t('goHome'),
-    goDashboard: t('goDashboard'),
     footer: t('footer'),
-  };
+    icon: 'clock',
+    actions: [
+      { href: ROUTES.REGISTER, label: t('cta'), variant: 'primary' },
+      { href: ROUTES.HOME, label: t('goHome'), variant: 'soft' },
+    ],
+  });
 
-  const links = {
-    goBack: 'javascript:history.back()',
-    goHome: ROUTES.HOME,
-    goDashboard: ROUTES.DASHBOARD,
-  };
-
-  return `<!doctype html>
-<html lang="${texts.head.lang}">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="color-scheme" content="light dark" />
-    <title>${texts.head.title}</title>
-    <meta name="title" />
-    <meta name="robots" content="noindex" />
-    <style>
-      :root {
-        --bg1: #eef4ff;
-        --bg2: #dde8ff;
-        --card: #ffffff;
-        --border: rgba(15, 23, 42, 0.14);
-        --shadow: 0 10px 26px rgba(15, 23, 42, 0.10);
-        --text: #0f172a;
-        --muted: rgba(15, 23, 42, 0.62);
-        --primary: #4f46e5;
-        --primaryHover: #4338ca;
-        --accent: #2563eb;
-        --radius: 16px;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        :root {
-          --bg1: #0b1222;
-          --bg2: #0a1020;
-          --card: rgba(255, 255, 255, 0.06);
-          --border: rgba(255, 255, 255, 0.14);
-          --shadow: 0 18px 60px rgba(0, 0, 0, 0.50);
-          --text: rgba(255, 255, 255, 0.92);
-          --muted: rgba(255, 255, 255, 0.68);
-          --primary: #6366f1;
-          --primaryHover: #4f46e5;
-          --accent: #60a5fa;
-        }
-      }
-
-      * { box-sizing: border-box; }
-      html, body { height: 100%; }
-
-      body {
-        margin: 0;
-        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
-        color: var(--text);
-        background:
-          radial-gradient(900px 560px at 30% 10%, rgba(79,70,229,0.16), transparent 62%),
-          radial-gradient(820px 520px at 78% 12%, rgba(37,99,235,0.10), transparent 62%),
-          linear-gradient(180deg, var(--bg1), var(--bg2));
-        display: grid;
-        place-items: center;
-        padding: 32px 16px;
-      }
-
-      .card {
-        width: min(720px, 100%);
-        background: var(--card);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        box-shadow: var(--shadow);
-        padding: 22px;
-        text-align: center;
-      }
-
-      .icon {
-        width: 56px;
-        height: 56px;
-        margin: 0 auto 10px;
-        border-radius: 16px;
-        display: grid;
-        place-items: center;
-        background: rgba(79, 70, 229, 0.10);
-        border: 1px solid rgba(79, 70, 229, 0.18);
-        color: var(--primary);
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .icon {
-          background: rgba(99, 102, 241, 0.14);
-          border-color: rgba(99, 102, 241, 0.22);
-        }
-      }
-
-      h1 {
-        margin: 6px 0 6px;
-        font-size: clamp(32px, 3.5vw, 52px);
-        letter-spacing: -0.03em;
-        line-height: 1.05;
-      }
-
-      p {
-        margin: 0 auto 16px;
-        max-width: 60ch;
-        color: var(--muted);
-        font-size: 15px;
-        line-height: 1.55;
-      }
-
-      .actions {
-        display: flex;
-        gap: 10px;
-        justify-content: center;
-        flex-wrap: wrap;
-        margin-top: 8px;
-      }
-
-      .btn {
-        text-decoration: none;
-        font-weight: 800;
-        font-size: 14px;
-        padding: 11px 14px;
-        border-radius: 12px;
-        border: 1px solid var(--border);
-        color: var(--text);
-        background: transparent;
-        transition: transform 120ms ease, background 120ms ease, border-color 120ms ease;
-      }
-
-      .btn:hover { transform: translateY(-1px); }
-
-      .btn.primary {
-        background: var(--primary);
-        border-color: transparent;
-        color: #fff;
-      }
-
-      .btn.primary:hover { background: var(--primaryHover); }
-
-      .btn.soft {
-        background: rgba(79, 70, 229, 0.08);
-        border-color: rgba(79, 70, 229, 0.18);
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .btn.soft {
-          background: rgba(99, 102, 241, 0.14);
-          border-color: rgba(99, 102, 241, 0.22);
-        }
-      }
-
-      .foot {
-        margin-top: 14px;
-        font-size: 13px;
-        color: var(--muted);
-      }
-
-      .foot a { color: var(--primary); font-weight: 800; text-decoration: none; }
-      .foot a:hover { text-decoration: underline; }
-    </style>
-  </head>
-
-  <body>
-    <main class="card" role="region" aria-label="404">
-      <div class="icon" aria-hidden="true">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-link h-8 w-8 text-indigo-600 mr-2" aria-hidden="true">
-          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
-          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
-        </svg>
-      </div>
-
-      <h1>${texts.title}</h1>
-      <p>${texts.subtitle}</p>
-
-      <div class="actions">
-        <a class="btn primary" href="${links.goHome}">${texts.goHome}</a>
-        <a class="btn soft" href="${links.goDashboard}">${texts.goDashboard}</a>
-        <a class="btn" href="${links.goBack}" rel="nofollow">${texts.goBack}</a>
-      </div>
-
-      <div class="foot">
-        <a href="${links.goHome}" rel="nofollow">iny.one</a> · ${texts.footer}
-      </div>
-    </main>
-  </body>
-</html>`;
+  return new NextResponse(html, { status: 410, headers: HTML_HEADERS });
 }

--- a/src/app/api/dashboard/stats/route.ts
+++ b/src/app/api/dashboard/stats/route.ts
@@ -11,8 +11,11 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { createClient } from "@/lib/supabase/server";
 import { ERROR } from "@/lib/api/error-codes";
+import { logger } from "@/lib/logger";
 
 dayjs.extend(utc);
+
+const log = logger.child({ route: 'api/dashboard/stats' });
 
 /** Links por página en la tabla del dashboard. */
 const PAGE_SIZE = 20;
@@ -44,6 +47,11 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     userRepo.getTopLinks(user.id, TOP_LINKS),
   ]);
 
+  // Un fallo aquí no puede degradarse en silencio: `data` vendría vacío y el
+  // dashboard mostraría cero enlaces como si la cuenta no tuviera ninguno, que
+  // es indistinguible de un problema real de permisos o de conexión.
+  assertNoError({ allSlugs, pageUrls, topLinks });
+
   const slugs = (allSlugs.data ?? []).map((item) => item.slug).filter((slug): slug is string => slug !== null);
 
   const [summaryResponse, refererResponse] = await Promise.all([
@@ -52,6 +60,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   ]);
 
   if (!summaryResponse.data || summaryResponse.error) {
+    log.error('failed to fetch stats summary', { error: summaryResponse.error });
     throw new ApiError(ERROR.INTERNAL_ERROR, 'Error fetching stats summary');
   }
 
@@ -68,3 +77,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     },
   });
 });
+
+/** Aborta con 500 si alguna de las consultas del panel devolvió error. */
+function assertNoError(responses: Record<string, { error: unknown }>): void {
+  for (const [nombre, response] of Object.entries(responses)) {
+    if (response.error) {
+      log.error('dashboard query failed', { query: nombre, error: response.error });
+      throw new ApiError(ERROR.INTERNAL_ERROR, 'Error fetching dashboard data');
+    }
+  }
+}

--- a/src/app/api/shorten/route.ts
+++ b/src/app/api/shorten/route.ts
@@ -21,14 +21,12 @@ import { checkRateLimit, recordRateLimitUsage } from "@/lib/utils/rate-limits";
 import { ERROR } from "@/lib/api/error-codes";
 import { generateSlug, MAX_SLUG_INSERT_ATTEMPTS } from "@/lib/short-links/slug";
 import { buildDestination, type DestinationPlan } from "@/lib/short-links/destination";
+import { ANONYMOUS_LINK_TTL_DAYS } from "@/lib/short-links/expiry";
 import { logger } from "@/lib/logger";
 
 dayjs.extend(utc);
 
 const log = logger.child({ route: 'api/shorten' });
-
-/** Días de vigencia de un link creado sin cuenta. */
-const ANONYMOUS_LINK_TTL_DAYS = 180;
 
 /** Dominios que nunca pueden ser destino de un link. */
 const BLOCKED_DOMAINS = new Set(['iny.one', 'localhost']);

--- a/src/app/ui/(main)/page.tsx
+++ b/src/app/ui/(main)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 import HomeTitle from "@/components/HomeTitle";
 import UrlShortForm from "@/features/short_links/components/UrlShortForm";
+import AnonymousLinkNotice from "@/features/short_links/components/AnonymousLinkNotice";
 import UtmInfoSmall from "@/components/UtmInfoSmall";
 import SubscriptionUpgrade from "@/components/SubscriptionUpgrade";
 import HomeContent from "@/components/HomeContent";
@@ -141,6 +142,7 @@ export default function HomePage() {
       <div className="max-w-2xl mx-auto">
         <HomeTitle />
         <UrlShortForm />
+        <AnonymousLinkNotice />
         <UtmInfoSmall />
       </div>
       <HomeContent />

--- a/src/features/dashboard/components/modal/EditLink.tsx
+++ b/src/features/dashboard/components/modal/EditLink.tsx
@@ -3,7 +3,7 @@ import { Button, Field, Fieldset, Input, Label } from "@headlessui/react";
 import React, { type ChangeEvent, useActionState, useEffect, useState } from "react";
 import Form from "next/form";
 import { editLinkAction } from "@/features/dashboard/actions/edit_link.actions";
-import { useStatsCommon } from "@/features/dashboard/hooks/useStatsCommon";
+import { useRefreshStats } from "@/features/dashboard/hooks/useStatsCommon";
 
 interface Props {
   link: UserUrlStats;
@@ -21,14 +21,15 @@ const initialState = {
 export default function EditLink({ link, t, onClose }: Readonly<Props>) {
   const [state, formAction] = useActionState(editLinkAction, { ...initialState, slug: link.slug });
 
-  const { mutateAlias } = useStatsCommon();
+  const refreshStats = useRefreshStats();
 
   useEffect(() => {
-    if(state?.success === true) {
-      mutateAlias(state.slug, state.alias)
-        .then(onClose)
-        .catch(console.error);
-    }
+    if (state?.success !== true) return;
+    void refreshStats().then(onClose);
+    // Sólo debe dispararse cuando la acción del servidor devuelve un resultado
+    // nuevo. `refreshStats` y `onClose` se recrean en cada render, así que
+    // incluirlos reabriría el efecto en bucle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
 
   const [alias, setAlias] = useState(link.alias ?? '');
@@ -37,48 +38,57 @@ export default function EditLink({ link, t, onClose }: Readonly<Props>) {
 
   const onChangeAlias = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
-    if(REGEX_ALIAS.test(value)) {
-      setError(t("modal.edit.error_alias_invalid"));
-      setDisabled(true);
-    } else {
-      setError(undefined);
-      setDisabled(false);
-    }
-    setAlias(e.target.value);
+    const invalid = REGEX_ALIAS.test(value);
+
+    setError(invalid ? t("modal.edit.error_alias_invalid") : undefined);
+    setDisabled(invalid);
+    setAlias(value);
   }
 
   return (
     <Form action={formAction}>
-      <div className="mt-4 grid grid-cols-1 gap-4">
-        <div className="space-y-3">
-          <Fieldset>
-            <Input
-              name="slug"
-              type="hidden"
-              value={link.slug}
-            />
-            <Field>
-              <Label className="block text-sm font-medium text-gray-700">
-                Alias
-              </Label>
-              <div className="mt-1">
-                <Input
-                  name="alias"
-                  type="text"
-                  value={alias}
-                  onChange={onChangeAlias}
-                  className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                />
-                {error && <p className="mt-2 text-sm text-red-600" id="alias-error">{error}</p>}
-              </div>
-            </Field>
-          </Fieldset>
-        </div>
-      </div>
-      <div className="mt-4 grid grid-cols-1 gap-4">
-        <div className="space-y-3">
-          <Button type="submit" disabled={disabled}>{t("modal.edit.save")}</Button>
-        </div>
+      <Fieldset className="mt-4">
+        <Input name="slug" type="hidden" value={link.slug} />
+        <Field>
+          <Label className="block text-sm font-medium text-gray-700">Alias</Label>
+          <Input
+            name="alias"
+            type="text"
+            value={alias}
+            onChange={onChangeAlias}
+            autoFocus
+            aria-invalid={Boolean(error)}
+            aria-describedby={error ? "alias-error" : undefined}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm
+                       focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none
+                       data-[invalid]:border-red-500"
+          />
+          {error
+            ? <p className="mt-2 text-sm text-red-600" id="alias-error">{error}</p>
+            : <p className="mt-2 text-sm text-gray-500">iny.one/{link.slug}</p>}
+        </Field>
+      </Fieldset>
+
+      <div className="mt-6 flex justify-end gap-2">
+        <Button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700
+                     cursor-pointer hover:bg-gray-50 focus:outline-none focus-visible:ring-2
+                     focus-visible:ring-indigo-500 focus-visible:ring-offset-2"
+        >
+          {t("modal.edit.cancel")}
+        </Button>
+        <Button
+          type="submit"
+          disabled={disabled}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm
+                     cursor-pointer hover:bg-indigo-700 focus:outline-none focus-visible:ring-2
+                     focus-visible:ring-indigo-500 focus-visible:ring-offset-2
+                     disabled:cursor-not-allowed disabled:bg-indigo-300"
+        >
+          {t("modal.edit.save")}
+        </Button>
       </div>
     </Form>
   );

--- a/src/features/dashboard/containers/UserDashboard.tsx
+++ b/src/features/dashboard/containers/UserDashboard.tsx
@@ -29,6 +29,7 @@ export function UserDashboard() {
   const {
     t,
     stats,
+    countChartOptions,
     page,
     totalPages,
     setPage,
@@ -95,7 +96,7 @@ export function UserDashboard() {
                   <div className="text-sm text-gray-500">{t("panel.weekActivity.subtitle")}</div>
                 </div>
                 <div className="h-52 w-full">
-                  <Line data={clicks_week} options={{ maintainAspectRatio: false }} />
+                  <Line data={clicks_week} options={countChartOptions} />
                 </div>
               </div>
 
@@ -105,10 +106,7 @@ export function UserDashboard() {
                   <div className="text-sm text-gray-500">{t("panel.performancePerLink.subtitle", { top: top_by_clicks })}</div>
                 </div>
                 <div className="h-52 w-full">
-                  <Bar
-                    data={clicks_top}
-                    options={{ maintainAspectRatio: false }}
-                  />
+                  <Bar data={clicks_top} options={countChartOptions} />
                 </div>
               </div>
             </div>

--- a/src/features/dashboard/hooks/useStatsCommon.ts
+++ b/src/features/dashboard/hooks/useStatsCommon.ts
@@ -1,24 +1,30 @@
 import { getStatsCommon } from "@/features/dashboard/services/getStats";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
+
+const STATS_KEY = ['stats', 'common'] as const;
 
 export const useStatsCommon = (page = 1) => {
-  const { data, error, isLoading, isValidating, mutate } = useSWR(
-    ['stats', 'common', page],
+  const { data, error, isLoading, isValidating } = useSWR(
+    [...STATS_KEY, page],
     ([, , currentPage]: [string, string, number]) => getStatsCommon(currentPage),
     { keepPreviousData: true },
   );
 
-  const mutateAlias = async (slug: string, alias: string) => {
-    if(!data) return;
-    const mutatedUrls = data.urls.map(url => url.slug === slug ? { ...url, alias } : url);
-    await mutate({ ...data, urls: mutatedUrls }, false);
-  }
+  return { data, isLoading, isValidating, error };
+}
 
-  return {
-    data,
-    isLoading,
-    isValidating,
-    error,
-    mutateAlias,
-  };
+/**
+ * Revalida las estadísticas de **todas** las páginas cacheadas.
+ *
+ * No se suscribe a ninguna: quien edita un alias no necesita los datos, sólo
+ * invalidarlos. Antes esto se hacía desde `useStatsCommon()` sin argumentos, lo
+ * que actualizaba siempre la caché de la página 1 aunque el usuario estuviera
+ * viendo otra, y además abría una segunda petición sólo para obtener la función.
+ */
+export const useRefreshStats = () => {
+  const { mutate } = useSWRConfig();
+
+  return () => mutate(
+    (key) => Array.isArray(key) && key[0] === STATS_KEY[0] && key[1] === STATS_KEY[1],
+  );
 }

--- a/src/features/dashboard/hooks/useUserDashboard.tsx
+++ b/src/features/dashboard/hooks/useUserDashboard.tsx
@@ -5,6 +5,26 @@ import { useTranslations } from "next-intl";
 import { UserUrl } from "@/features/dashboard/types/types";
 import { calcUserStats } from "@/features/dashboard/helpers/stats";
 
+/**
+ * Opciones comunes de los gráficos de clics. Los clics son enteros no negativos:
+ * sin `beginAtZero` Chart.js dibuja el eje de -1 a 1 cuando todos los valores
+ * son cero, y sin `precision: 0` marca decimales como "0,5 clics".
+ *
+ * Se define aquí y no en components/charts para no importar ese módulo de forma
+ * estática: se carga con next/dynamic justo para mantener chart.js fuera del
+ * bundle inicial.
+ */
+const countChartOptions = {
+  maintainAspectRatio: false,
+  scales: {
+    y: {
+      beginAtZero: true,
+      suggestedMax: 4,
+      ticks: { precision: 0 },
+    },
+  },
+};
+
 export const useUserDashboard = () => {
   const t = useTranslations('DashboardPage');
   const [modal, setModal] = useState<ILinkDetails>({
@@ -89,6 +109,7 @@ export const useUserDashboard = () => {
   return {
     t,
     stats,
+    countChartOptions,
     page,
     totalPages,
     setPage,

--- a/src/features/short_links/components/AnonymousLinkNotice.tsx
+++ b/src/features/short_links/components/AnonymousLinkNotice.tsx
@@ -1,0 +1,35 @@
+import { ClockIcon } from "lucide-react";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import { isLoggedIn } from "@/data/dto/user-dto";
+import { ANONYMOUS_LINK_TTL_DAYS } from "@/lib/short-links/expiry";
+import { ROUTES } from "@/lib/routes";
+
+/**
+ * Avisa de que los enlaces creados sin cuenta caducan, y sólo a quien no ha
+ * iniciado sesión: para un usuario autenticado el plazo no aplica y el mensaje
+ * sería ruido.
+ *
+ * El plazo sale de la misma constante que usa /api/shorten al fijar
+ * `expires_at`, para que el aviso no pueda prometer algo distinto.
+ */
+export default async function AnonymousLinkNotice() {
+  if (await isLoggedIn()) return null;
+
+  const t = await getTranslations('HomePage');
+
+  return (
+    <p className="mt-3 flex items-center justify-center gap-2 text-center text-sm text-gray-500">
+      <ClockIcon className="h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+      <span>
+        {t('anonymousNotice', { days: ANONYMOUS_LINK_TTL_DAYS })}{' '}
+        <Link
+          href={ROUTES.REGISTER}
+          className="font-semibold text-indigo-600 underline-offset-2 hover:underline"
+        >
+          {t('anonymousNoticeCta')}
+        </Link>
+      </span>
+    </p>
+  );
+}

--- a/src/infra/db/shorter.repository.ts
+++ b/src/infra/db/shorter.repository.ts
@@ -43,12 +43,17 @@ export function getShorterRepository(db: DbInstance) {
         .select('slug');
     },
 
+    /**
+     * No filtra por `status`: lo devuelve para que el resolver pueda distinguir
+     * un enlace caducado de uno inexistente y mostrar cada pantalla. Filtrarlo
+     * hacía que, tras la primera visita a un caducado, la fila desapareciera de
+     * la consulta y ambos casos quedaran indistinguibles.
+     */
     async getBySlug(slug: string) {
       return db
         .from('short_links')
-        .select('destination, expires_at')
+        .select('destination, expires_at, status')
         .eq('slug', slug)
-        .eq('status', true)
         .maybeSingle();
     },
 

--- a/src/lib/short-links/expiry.ts
+++ b/src/lib/short-links/expiry.ts
@@ -1,0 +1,9 @@
+/**
+ * Días que vive un enlace creado sin cuenta.
+ *
+ * Vive aquí, sin dependencias, porque lo consumen dos sitios que no pueden
+ * discrepar: la ruta que fija `expires_at` al crear el enlace y el aviso que se
+ * muestra en la home a quien no ha iniciado sesión. Si el valor se duplicara,
+ * la interfaz acabaría prometiendo un plazo distinto del que aplica el servidor.
+ */
+export const ANONYMOUS_LINK_TTL_DAYS = 180;

--- a/src/lib/short-links/resolve-link-state.ts
+++ b/src/lib/short-links/resolve-link-state.ts
@@ -1,0 +1,33 @@
+export type LinkRow = {
+  destination: string | null;
+  expires_at: string | null;
+  status: boolean | null;
+};
+
+export type LinkState = 'not-found' | 'expired' | 'active';
+
+/**
+ * Decide qué responder ante un slug, a partir de la fila encontrada.
+ *
+ * Se separa del route handler porque es la única lógica con ramas del resolver
+ * y conviene poder probarla sin montar una petición.
+ *
+ * - `expired` sólo para enlaces que caducaron por tiempo. Es lo que habilita la
+ *   pantalla de reconversión, así que debe distinguirse de un slug inexistente.
+ * - Un enlace desactivado sin fecha de caducidad se trata como inexistente: no
+ *   sabemos por qué se desactivó y no procede insinuar que existió.
+ */
+export function resolveLinkState(link: LinkRow | null, now: Date = new Date()): LinkState {
+  if (!link?.destination) return 'not-found';
+
+  const expiresAt = link.expires_at ? new Date(link.expires_at) : null;
+  const hasValidExpiry = expiresAt !== null && !Number.isNaN(expiresAt.getTime());
+
+  if (hasValidExpiry && expiresAt.getTime() <= now.getTime()) return 'expired';
+
+  // `status` a false lo escribe el propio resolver la primera vez que alguien
+  // visita un enlace ya caducado, así que sigue siendo un caducado.
+  if (link.status === false) return hasValidExpiry ? 'expired' : 'not-found';
+
+  return 'active';
+}

--- a/src/lib/short-links/status-page.ts
+++ b/src/lib/short-links/status-page.ts
@@ -1,0 +1,228 @@
+/**
+ * Plantilla HTML de las páginas que devuelve el resolver de enlaces cortos
+ * (404 y 410). Se sirven fuera del árbol de React, así que van como cadena.
+ *
+ * Vive aquí y no dentro del route handler para que las dos variantes compartan
+ * estilos en lugar de duplicarlos.
+ */
+
+export type StatusPageAction = {
+  href: string;
+  label: string;
+  variant?: 'primary' | 'soft' | 'plain';
+  rel?: string;
+};
+
+export type StatusPageOptions = {
+  lang: string;
+  metaTitle: string;
+  headline: string;
+  subtitle: string;
+  actions: StatusPageAction[];
+  footer: string;
+  icon?: 'link' | 'clock';
+};
+
+/** Los textos vienen de las traducciones, pero se interpolan en HTML crudo. */
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+const ICONS = {
+  link: '<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>',
+  clock: '<circle cx="12" cy="12" r="10"></circle><polyline points="12 6 12 12 16 14"></polyline>',
+} as const;
+
+export function renderStatusPage({
+  lang,
+  metaTitle,
+  headline,
+  subtitle,
+  actions,
+  footer,
+  icon = 'link',
+}: StatusPageOptions): string {
+  const buttons = actions
+    .map(({ href, label, variant = 'plain', rel }) => {
+      const cls = variant === 'plain' ? 'btn' : `btn ${variant}`;
+      const relAttr = rel ? ` rel="${escapeHtml(rel)}"` : '';
+      return `<a class="${cls}" href="${escapeHtml(href)}"${relAttr}>${escapeHtml(label)}</a>`;
+    })
+    .join('\n        ');
+
+  return `<!doctype html>
+<html lang="${escapeHtml(lang)}">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <title>${escapeHtml(metaTitle)}</title>
+    <meta name="robots" content="noindex" />
+    <style>
+      :root {
+        --bg1: #eef4ff;
+        --bg2: #dde8ff;
+        --card: #ffffff;
+        --border: rgba(15, 23, 42, 0.14);
+        --shadow: 0 10px 26px rgba(15, 23, 42, 0.10);
+        --text: #0f172a;
+        --muted: rgba(15, 23, 42, 0.62);
+        --primary: #4f46e5;
+        --primaryHover: #4338ca;
+        --radius: 16px;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg1: #0b1222;
+          --bg2: #0a1020;
+          --card: rgba(255, 255, 255, 0.06);
+          --border: rgba(255, 255, 255, 0.14);
+          --shadow: 0 18px 60px rgba(0, 0, 0, 0.50);
+          --text: rgba(255, 255, 255, 0.92);
+          --muted: rgba(255, 255, 255, 0.68);
+          --primary: #6366f1;
+          --primaryHover: #4f46e5;
+        }
+      }
+
+      * { box-sizing: border-box; }
+      html, body { height: 100%; }
+
+      body {
+        margin: 0;
+        font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+        color: var(--text);
+        background:
+          radial-gradient(900px 560px at 30% 10%, rgba(79,70,229,0.16), transparent 62%),
+          radial-gradient(820px 520px at 78% 12%, rgba(37,99,235,0.10), transparent 62%),
+          linear-gradient(180deg, var(--bg1), var(--bg2));
+        display: grid;
+        place-items: center;
+        padding: 32px 16px;
+      }
+
+      .card {
+        width: min(720px, 100%);
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        text-align: center;
+      }
+
+      .icon {
+        width: 56px;
+        height: 56px;
+        margin: 0 auto 10px;
+        border-radius: 16px;
+        display: grid;
+        place-items: center;
+        background: rgba(79, 70, 229, 0.10);
+        border: 1px solid rgba(79, 70, 229, 0.18);
+        color: var(--primary);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .icon {
+          background: rgba(99, 102, 241, 0.14);
+          border-color: rgba(99, 102, 241, 0.22);
+        }
+      }
+
+      h1 {
+        margin: 6px 0 6px;
+        font-size: clamp(28px, 3.2vw, 44px);
+        letter-spacing: -0.03em;
+        line-height: 1.1;
+      }
+
+      p {
+        margin: 0 auto 16px;
+        max-width: 56ch;
+        color: var(--muted);
+        font-size: 15px;
+        line-height: 1.55;
+      }
+
+      .actions {
+        display: flex;
+        gap: 10px;
+        justify-content: center;
+        flex-wrap: wrap;
+        margin-top: 8px;
+      }
+
+      .btn {
+        text-decoration: none;
+        font-weight: 800;
+        font-size: 14px;
+        padding: 11px 14px;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        color: var(--text);
+        background: transparent;
+        transition: transform 120ms ease, background 120ms ease, border-color 120ms ease;
+      }
+
+      .btn:hover { transform: translateY(-1px); }
+
+      .btn.primary {
+        background: var(--primary);
+        border-color: transparent;
+        color: #fff;
+      }
+
+      .btn.primary:hover { background: var(--primaryHover); }
+
+      .btn.soft {
+        background: rgba(79, 70, 229, 0.08);
+        border-color: rgba(79, 70, 229, 0.18);
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .btn.soft {
+          background: rgba(99, 102, 241, 0.14);
+          border-color: rgba(99, 102, 241, 0.22);
+        }
+      }
+
+      .foot {
+        margin-top: 14px;
+        font-size: 13px;
+        color: var(--muted);
+      }
+
+      .foot a { color: var(--primary); font-weight: 800; text-decoration: none; }
+      .foot a:hover { text-decoration: underline; }
+    </style>
+  </head>
+
+  <body>
+    <main class="card" role="region" aria-label="${escapeHtml(headline)}">
+      <div class="icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          ${ICONS[icon]}
+        </svg>
+      </div>
+
+      <h1>${escapeHtml(headline)}</h1>
+      <p>${escapeHtml(subtitle)}</p>
+
+      <div class="actions">
+        ${buttons}
+      </div>
+
+      <div class="foot">
+        <a href="/" rel="nofollow">iny.one</a> · ${escapeHtml(footer)}
+      </div>
+    </main>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
Introduce robust handling for expired short links: add ANONYMOUS_LINK_TTL_DAYS, resolveLinkState, and a shared HTML status-page renderer; route /[short] now uses the resolver to return 410 for expired links and 404 for not-found, and writes status=false on first-expiry. Update repository to return status, add AnonymousLinkNotice on home, and i18n strings for anonymous/expired messages. Add unit tests for resolver and status page. Also: improve dashboard error logging/assertion, chart options, useRefreshStats hook and EditLink UI tweaks. Update remediation SQL and CLAUDE.md notes about function EXECUTE grants.