### PR TITLE
Add handover docs and fix CSP GA4 origins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,20 @@ Cada una de estas costó un ciclo de trabajo. Leerlas antes de explorar el repo.
   «sin referencias».
 - `service.repository.ts` (singular) y `services.repository.ts` (plural, lo usa el carrito) son
   ficheros distintos con nombres casi idénticos.
+- GA4 **no** envía la medición a `www.google-analytics.com`. Verificado en la consola de producción
+  el 2026-08-14: el `page_view` sale a `https://analytics.google.com/g/collect`. Ese host tiene que
+  estar en `connect-src`; los endpoints regionales (`region1.google-analytics.com`…) se cubren con
+  el comodín, y en CSP `*.dominio` **no** cubre `dominio`, por eso hacen falta las dos formas.
+  Si falta, gtag.js carga igual —está en `script-src`— y sólo se bloquea `/g/collect`: parece que
+  el tag está puesto y no mide.
+- Con Google Signals activo, GA4 dispara además `stats.g.doubleclick.net/g/collect`,
+  `www.google.com/g/collect` y `www.google.<tld>/ads/ga-audiences`. **No están en la allowlist a
+  propósito** (decisión del 2026-08-14): son demografía y remarketing, no informes estándar, y el
+  último va al dominio de Google del país de cada visitante, que no admite lista finita. Si
+  aparecen en la consola es que Signals sigue activo en GA4; se desactiva allí, no ampliando la CSP.
+- Un HAR **no** sirve para diagnosticar bloqueos de CSP: las peticiones que la política corta no
+  llegan a la capa de red y no se exportan. Sólo se ven en la consola. Diagnosticar con HAR una
+  sospecha de CSP es una comprobación que no distingue «funciona» de «está roto».
 - En PostgreSQL toda función nace con `EXECUTE` concedido a **PUBLIC**, y `anon` lo hereda por ahí:
   `revoke execute ... from anon` no le quita nada. Hay que revocar a `public`, y eso también se lo
   quita a `service_role`, así que después toca devolvérselo explícitamente. Verificado en PG 16.

--- a/docs/handover-2026-08-09.md
+++ b/docs/handover-2026-08-09.md
@@ -1,0 +1,202 @@
+# iny.one — resumen de cambios, 8 y 9 de agosto de 2026
+
+Documento de traspaso. Resume qué se tocó, por qué, y qué queda pendiente.
+
+Todo lo entregado pasa `yarn verify` (lint, typegen, typecheck y 138 tests) y `next build`.
+
+---
+
+## 1. Lo urgente: fuga de datos personales en Supabase
+
+**Qué pasaba.** RLS estaba activo en las diecisiete tablas, pero dos políticas tenían
+`using (true)` para el rol `public`:
+
+- `history_clicks` — 35 194 filas con IP, país, región, ciudad, latitud, longitud, user agent y
+  referer de cada clic.
+- `short_links` — destino, `user_id` e `ip_user` de los 2 636 enlaces, de todos los usuarios.
+
+Cualquiera con la clave anónima —que viaja en el bundle del navegador y es pública por diseño— podía
+leer ambas tablas enteras con una petición a PostgREST.
+
+**Qué se hizo.** Se eliminaron esas dos políticas. `short_links` quedó con `short_links_select_own` y
+`short_links_update_own`, ambas para `authenticated` y acotadas a `user_id = auth.uid()`.
+`history_clicks` quedó con RLS y cero políticas: denegada salvo para el service role, que es quien la
+lee de verdad.
+
+**Verificación.** Con la clave anónima real contra la API de producción, ambas tablas devuelven `[]`.
+No es inferencia sobre el catálogo, es la respuesta del servicio.
+
+**Efecto colateral positivo.** La política de UPDATE arregló un bug latente: `changeAlias` escribía
+con la sesión del usuario y, sin política, PostgREST devolvía cero filas afectadas **sin error**. La
+edición de alias llevaba tiempo fallando en silencio. Confirmado: ninguno de los seis enlaces de la
+cuenta de prueba tenía alias pese a llevar meses. Ahora persiste.
+
+## 2. Resto del endurecimiento de la base de datos
+
+**Privilegios.** `anon` y `authenticated` tenían `DELETE, INSERT, REFERENCES, SELECT, TRIGGER,
+TRUNCATE, UPDATE` sobre todas las tablas de `public` (el grant por defecto de la plantilla de
+Supabase). Se revocó todo y se concedió sólo `select, update on public.short_links to authenticated`.
+Importa porque `TRUNCATE` **no está sujeto a RLS** y porque bastaba desactivar RLS en una tabla por
+error para exponerla entera.
+
+**Funciones.** `public.get_page_traffic` es `SECURITY DEFINER` y era ejecutable por `anon`: permitía
+pedir el tráfico de cualquier slug por RPC saltándose la aplicación. Revocada, junto con
+`security.insert_blocked_url`.
+
+> **Trampa que costó un ciclo:** en PostgreSQL toda función nace con `EXECUTE` concedido a `PUBLIC`,
+> y `anon` lo hereda por ahí. `revoke execute ... from anon` no le quita nada — comprobado en un
+> PostgreSQL 16 real. Hay que revocar a `public`, y eso también se lo quita a `service_role`, así que
+> después hay que devolvérselo explícitamente o se rompe lo que sí usa la aplicación.
+
+**Autorización en la API.** `GET /api/dashboard/stats/[slug]` no comprobaba **ni sesión ni
+pertenencia**, y leía con el service role (que salta RLS). Cualquiera que conociera un slug obtenía
+la analítica diaria de ese enlace. Ahora exige sesión y verifica propiedad. Cubierto con cinco tests
+de regresión.
+
+**Esquema `security`.** Auditado: cuatro tablas (`blocked_url`, `blocklist_url_phishing_active`,
+`cached_blocked_url`, `whitelist_url`), todas con RLS y sin ningún grant a `anon` ni `authenticated`.
+Limpio, no hizo falta tocarlo.
+
+## 3. Bugs de corrección encontrados y corregidos
+
+**Destrucción de parámetros de la URL destino (el más grave).** En `buildDestination`, la rama `else`
+reasignaba cada parámetro de la query con `utm[nombre]`, de modo que **todo parámetro ajeno a los UTM
+quedaba con el literal `undefined`**. Reproducido: `https://example.com/search?q=hello&page=2` se
+guardaba como `?q=undefined&page=undefined`. Cualquier enlace con query string se almacenaba roto.
+
+**KPI del dashboard calculados sobre datos truncados.** `getStatsUserUrls` tenía un `.limit(20)` fijo
+y el resumen se calculaba sobre esos mismos veinte slugs. Una cuenta con más enlaces veía clics
+totales, país principal y gráfico semanal calculados sobre un subconjunto arbitrario, sin ninguna
+señal. Ahora los agregados usan todos los slugs, la tabla pagina y el ranking de mejores enlaces sale
+de su propia consulta.
+
+**`decodeURI` sin guarda.** Un destino con un `%` suelto lanza `URIError`, tanto al crear el enlace
+como en **cada** visita. 500 no controlado en la ruta de más tráfico.
+
+**Rate limiting que fallaba abierto.** Un usuario autenticado sin plan en su metadata salía del
+`else if` sin ninguna comprobación y creaba enlaces sin límite. Lo mismo para una petición anónima
+sin IP resoluble. Ahora ambos casos caen a la cuota `free`.
+
+**Colisión de slugs sin reintento.** Un choque de `nanoid` devolvía un 500. Ahora se inserta de forma
+optimista y se reintenta ante el error `23505` de Postgres, hasta cinco veces. Se evita el `SELECT`
+previo a propósito: no elimina la condición de carrera y añade una consulta por creación. (La
+auditoría confirmó que `short_links_pkey` es `PRIMARY KEY (slug)`, así que la garantía existe.)
+
+**Dashboard que se rompía con una cuenta nueva.** `all_time.top_countries[0].name` sin comprobar
+longitud. Una cuenta sin clics reventaba el panel.
+
+**Errores de consulta tragados.** `/api/dashboard/stats` sólo comprobaba el error del resumen; los
+demás caían en `data ?? []` y devolvían un panel vacío indistinguible de "no tienes enlaces". Ahora
+se validan todos y se registra cuál falló.
+
+## 4. Seguridad de la aplicación
+
+**Content-Security-Policy** en `next.config.ts`, con allowlist de orígenes (Supabase derivado de la
+variable de entorno, Google Analytics, PayPal, avatares de Google), `object-src 'none'`, `base-uri`,
+`form-action`, `frame-ancestors` y `upgrade-insecure-requests`. `'unsafe-eval'` sólo en desarrollo.
+Hay un toggle `CSP_REPORT_ONLY=true` para validarla sin aplicarla. `script-src` conserva
+`'unsafe-inline'` por el gtag en línea y los bloques JSON-LD; endurecerla con nonce está pendiente.
+
+> **Esta CSP rompió GA4 y estuvo así del 9 al 14 de agosto.** La allowlist incluía
+> `www.google-analytics.com`, que GA4 no usa: la medición sale a
+> `https://analytics.google.com/g/collect`. Al faltar en `connect-src`, el navegador bloqueaba cada
+> `page_view` y GA4 no registró ni una visita. Corregido el 14 de agosto añadiendo
+> `https://analytics.google.com` y el comodín `https://*.google-analytics.com` (endpoints
+> regionales `region1…region9`); en CSP `*.dominio` **no** cubre `dominio`, hacen falta las dos
+> formas.
+>
+> Dos lecciones que costaron tres vueltas y quedan en `CLAUDE.md`. La primera: **un HAR no sirve
+> para diagnosticar CSP** — las peticiones que la política corta no llegan a la capa de red y no se
+> exportan, así que se ven como «no existen», que es indistinguible de «el tag no dispara». La
+> prueba estaba en la consola desde el principio. La segunda: escribir un fichero en disco no es
+> commitearlo. El arreglo estuvo tres intentos en el working tree sin llegar a producción, y cada
+> prueba salía idéntica porque la variable bajo sospecha no se había movido.
+>
+> Con Google Signals activo GA4 dispara además `stats.g.doubleclick.net/g/collect`,
+> `www.google.com/g/collect` y `www.google.<tld>/ads/ga-audiences`. **Se decidió no allowlistarlos**:
+> son demografía y remarketing, no informes estándar, y el último va al dominio de Google del país
+> de cada visitante, que no admite lista finita. Se desactiva Signals en GA4 en lugar de meter
+> dominios de ad-tech en la política.
+
+**Logger estructurado** en `src/lib/logger.ts`: niveles, JSON por línea en producción, texto legible
+en desarrollo, loggers hijo con contexto ligado y redacción automática de claves sensibles a
+cualquier profundidad. Sustituye `console.*` en el resolver, auth, callback OAuth y server actions.
+
+## 5. Producto y UX
+
+- **Paginación del dashboard**, 20 por página, con el total real y controles anterior/siguiente.
+- **Pantalla de enlace caducado**: responde **410 Gone** (correcto para algo que existió, le dice a
+  Google que desindexe) con copy propio y llamada a registrarse. Antes caía en el 404 genérico,
+  indistinguible de un slug inexistente. Requirió que `getBySlug` dejara de filtrar por `status`:
+  filtrarlo hacía que tras la primera visita ambos casos fueran indistinguibles.
+- **Aviso en la home** para usuarios no autenticados: los enlaces sin cuenta caducan a los 180 días,
+  con enlace a registro. El plazo sale de la misma constante que usa la API, para que no puedan
+  discrepar.
+- **Botones del modal de edición**: el "Guardar" era texto plano porque el `<Button>` de Headless UI
+  se renderiza sin estilos, y el input tenía `border-gray-300` sin la clase `border`, que en Tailwind
+  fija el color pero no el grosor. Se añadió botón primario con estado deshabilitado, cancelar, foco
+  visible por teclado y previsualización del slug.
+- **Ejes de los gráficos**: `beginAtZero` y `precision: 0`. Antes el eje iba de −1 a 1 con datos a
+  cero y marcaba medios clics.
+- **`noindex` del área privada**: estaba declarado en `app/ui/dashboard/layout.tsx`, un layout
+  huérfano fuera de la cadena de renderizado, así que **nunca se aplicaba**. Movido a
+  `app/ui/(user)/layout.tsx`. En `robots.txt`, las reglas eran `Disallow: /dashboard/` con barra
+  final, que no cubre `/dashboard` exacto.
+
+## 6. Infraestructura del repositorio
+
+- **`yarn verify`**: lint + typegen + typecheck + tests en un comando.
+- **CI en GitHub Actions** (`.github/workflows/ci.yml`) en push y PR contra `main` y `develop`.
+- **ESLint**: el repo declaraba las dependencias y el script `lint`, pero **no existía fichero de
+  configuración**, así que el comando fallaba antes de analizar nada.
+- **138 tests** en 14 suites. Antes había uno solo y estaba **roto**: fallaba con `SyntaxError` al
+  importar `next-intl/server`. La suite estaba en rojo, no simplemente vacía.
+- **`CLAUDE.md`**: contexto operativo para agentes de IA — comandos, fronteras, trampas verificadas
+  del repositorio y estado conocido de la base de datos con fechas.
+- **README** reescrito: describía una capa `core/` con entidades y casos de uso que no existe.
+- **Código inactivo**: nada se borra. Las unidades sin referencias quedan comentadas bajo cabecera
+  `INACTIVO`; los exports sueltos dentro de módulos vivos llevan `/** INACTIVO */` y siguen activos.
+  Inventario razonado en el README, listado actual con `rg INACTIVO src/`.
+
+## 7. Scripts SQL
+
+En `scripts/sql/`:
+
+- `auditoria.sql` — **una sola sentencia** que devuelve un JSON con índices, duplicados,
+  restricciones, RLS por objeto, políticas, funciones y sus permisos, grants de `anon`, volumen y
+  contadores. Es una sola a propósito: el SQL Editor de Supabase sólo muestra el resultado de la
+  última sentencia ejecutada.
+- `auditoria-ddl.sql` — planes de ejecución y DDL correctivo (comentado).
+- `remediacion.sql` — los pasos aplicados, con sus verificaciones y avisos.
+
+---
+
+## Pendiente
+
+**Sin resolver, por decisión de alcance:**
+
+- **PayPal.** Tres problemas conocidos y sin tocar. El más serio: `verifySignature` descarga el
+  certificado desde `paypal-cert-url`, un header de la petición entrante, sin validar que el dominio
+  sea de PayPal — permite falsificar eventos de webhook y además es un SSRF. Los otros dos: el
+  cliente tiene `logBody` y `logHeaders` activos, y el manejador de webhooks sólo procesa
+  `SUBSCRIPTION_EXPIRED` (una cancelación desde PayPal no se entera).
+- **El guard de webhooks nunca se ejecuta.** `checkWebhook` está en `src/middleware.ts`, pero el
+  matcher excluye `/api/*` y el webhook vive en `/api/webhooks`. Es un control de seguridad que
+  aparenta estar puesto y no corre.
+
+**Elegido no hacer ahora:**
+
+- Limpieza de los 1 904 enlaces caducados que siguen con `status = true`. Nota importante: **esos
+  enlaces ya no funcionan** — el resolver comprueba `expires_at` en cada visita. El `update` sólo
+  sincroniza la bandera. Si se quisiera que siguieran resolviendo, es un cambio de código (el TTL),
+  no de datos.
+- Índices `(user_id, created_at)` e `(ip_user, created_at)`. Las consultas de cuota hacen Seq Scan,
+  pero con 2 636 filas tardan 0,45 ms y el planificador elegiría recorrido secuencial igualmente. Es
+  previsión, no urgencia.
+- Conector MCP de Supabase (`.mcp.json` preparado en solo lectura y acotado al proyecto, sin activar).
+- Endurecer la CSP con nonce por petición.
+- Convertir `src/lib/types/db.types.d.ts` a UTF-8 y regenerarlo. Está en UTF-16, lo que hace que
+  `grep` y `rg` **fallen en silencio** dentro de él, y además está desactualizado: declara
+  `slug: string | null` y un `id` que ya no es la clave primaria.
+- 315 enlaces con desfase entre `short_links.clicks` y `short_links_stats.total_clicks`. Conviene
+  decidir cuál es la fuente de verdad; el ranking del dashboard usa `short_links.clicks`.

--- a/docs/instrucciones-proyecto.md
+++ b/docs/instrucciones-proyecto.md
@@ -1,0 +1,96 @@
+# iny.one — instrucciones del proyecto
+
+## Qué es iny.one
+
+Acortador de URLs con parámetros UTM, códigos QR y analítica de clics. Modelo freemium con planes
+free, basic y pro. Los enlaces creados sin cuenta caducan a los 180 días; ese plazo es a la vez una
+restricción de producto y la principal palanca de conversión.
+
+Público mayoritariamente chileno. El SEO bilingüe forma parte del producto, no es un adorno: inglés
+por defecto y español bajo `/es/*` con URLs propias, landings que traen tráfico y señales canónicas
+que hay que cuidar al tocar rutas o metadata.
+
+Stack: Next.js 15 (App Router), React 19, TypeScript, Tailwind 4, Supabase (Postgres + Auth) y
+Vercel. Repositorio `iny-one-full`.
+
+## Antes de tocar el repositorio
+
+Lee `CLAUDE.md` en la raíz: comandos, fronteras, trampas verificadas y estado conocido de la base de
+datos. **Mantenlo actualizado.** Si descubres una trampa que costó tiempo, o cambia el estado de la
+base, se anota ahí con fecha. No dupliques en él lo que ya está en el README: son capas distintas y
+si se solapan divergen.
+
+## Cómo escribir código
+
+Prefiere la solución más pequeña que sea correcta y legible. Borrar o reutilizar antes que añadir.
+El objetivo es menos código que mantener, no menos trabajo: los tests y el manejo de errores nunca
+cuentan como código de más.
+
+Refactoriza lo que ya estás tocando cuando reduzca complejidad. Un refactor grande se propone antes
+de hacerlo, nunca se entrega como sorpresa dentro de otra tarea.
+
+No borres código sin usar: se marca como inactivo con su disclaimer (convención en `CLAUDE.md`).
+No añadas dependencias sin explicar por qué no basta lo que ya hay.
+
+Terminado significa `yarn verify` en verde. Nada se declara funcionando sin evidencia; si algo no se
+pudo comprobar, dilo en lugar de darlo por bueno.
+
+## Verificar antes de afirmar
+
+Cuando algo se pueda comprobar ejecutándolo, compruébalo en vez de deducirlo. El razonamiento seguro
+falla más de lo que parece: un barrido de código muerto con patrones glob se saltó rutas con
+corchetes y dio falsos «sin referencias»; un `revoke` de permisos parecía correcto y no quitaba nada
+porque el privilegio se heredaba de `PUBLIC`. Ambos se cazaron ejecutando algo.
+
+Al reportar, distingue siempre lo verificado de lo inferido. Una comprobación que no puede
+diferenciar «funciona» de «está roto» no comprueba nada: diseña la prueba para que un error de
+configuración no se parezca a un éxito.
+
+## Fallos silenciosos
+
+Es el modo de fallo característico de este proyecto y merece atención específica. PostgREST devuelve
+cero filas sin error cuando RLS deniega; los errores de consulta se convierten en paneles vacíos si
+no se comprueban; `grep` no encuentra nada dentro de un fichero UTF-16. Un fallo que no se nota es
+peor que uno ruidoso. Ante la duda, falla visible y registra por qué.
+
+## Datos y base de datos
+
+La base es de producción y contiene datos personales: IPs, ciudades y coordenadas de usuarios
+reales. No ejecutes consultas que devuelvan filas personales cuando basten metadatos o agregados.
+
+Todo cambio en la base va en un script bajo `scripts/sql/`, con su verificación antes y después.
+Nada destructivo ni irreversible sin confirmarlo primero.
+
+## Modelo de datos y arquitectura
+
+Prioriza claridad y simpleza sobre elegancia. Una estructura obvia que alguien entiende en cinco
+minutos vale más que una abstracción correcta que exige un mapa.
+
+Escalabilidad aquí significa **no cerrarse puertas**, no construir para un tamaño que no se tiene.
+Una interfaz que permite cambiar de implementación después es barata; una infraestructura que nadie
+usa todavía, no. Cuando propongas optimizar, trae el dato del tamaño real antes de decidir: puede
+que el problema no exista aún.
+
+Mantén las fronteras que ya existen. El acceso a datos pasa por los repositorios de `src/infra/`, y
+las rutas no saben de Supabase. Si una decisión de arquitectura tiene alternativas razonables,
+expón el compromiso en dos líneas antes de elegir.
+
+## Cómo comunicarte
+
+Si algo que propongo está mal, es innecesario o hay un camino mejor, dilo. No valides por cortesía.
+Cuando te equivoques, corrígelo de forma explícita y explica qué falló, sobre todo si una conclusión
+anterior se apoyaba en ello.
+
+Decide y deja constancia del supuesto en lo reversible. Pregunta en lo que toca producción o no
+tiene vuelta atrás.
+
+Explica el porqué, no sólo el qué. Los comentarios en el código siguen la misma regla.
+
+## No hagas
+
+- Reescribir o reestructurar sin pedirlo.
+- Declarar algo verificado cuando sólo está razonado.
+- Tocar PayPal por iniciativa propia (ver fronteras en `CLAUDE.md`).
+- Dejar `console.*` en código de servidor: existe un logger.
+- Añadir documentación que describa el código en lugar de explicar decisiones. La que miente cuesta
+  más que la que falta.

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,12 +23,42 @@ const isDev = process.env.NODE_ENV !== "production";
 const supabaseOrigin = safeOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL);
 
 const PAYPAL_ORIGINS = ["https://www.paypal.com", "https://www.sandbox.paypal.com"];
-const ANALYTICS_ORIGINS = ["https://www.googletagmanager.com", "https://www.google-analytics.com"];
+/**
+ * GA4 no manda la medición a www.google-analytics.com. Verificado en la consola
+ * de producción el 2026-08-14: el `page_view` sale a
+ * `https://analytics.google.com/g/collect`, y al no estar en `connect-src` el
+ * navegador lo bloqueaba. Ese era el motivo de que GA4 no registrara visitas.
+ *
+ * El síntoma es engañoso y conviene recordarlo: gtag.js carga sin problemas
+ * —está en `script-src`— así que «el tag está puesto» y aun así no llega nada.
+ * El único sitio donde se ve es la consola; un HAR no exporta las peticiones
+ * que la CSP corta antes de la capa de red.
+ *
+ * `*.google-analytics.com` cubre los endpoints regionales documentados
+ * (region1…region9), que no aparecieron en esta prueba pero sí se usan en otras
+ * regiones. Es precaución, no un host observado. Ojo: en CSP el comodín NO
+ * cubre el dominio desnudo, por eso están las dos formas.
+ *
+ * Deliberadamente FUERA: stats.g.doubleclick.net, www.google.com/g/collect y
+ * www.google.<tld>/ads/ga-audiences. Son de Google Signals (demografía y
+ * remarketing), no de los informes estándar, y sólo se disparan con Signals
+ * activo. Se desactiva en GA4 en lugar de meter dominios de ad-tech en la
+ * allowlist. El último además va al dominio de Google del país de cada
+ * visitante, así que no hay lista finita que lo cubra.
+ */
+const ANALYTICS_SCRIPT_ORIGINS = ["https://www.googletagmanager.com"];
+
+const ANALYTICS_ORIGINS = [
+  ...ANALYTICS_SCRIPT_ORIGINS,
+  "https://analytics.google.com",
+  "https://www.google-analytics.com",
+  "https://*.google-analytics.com",
+];
 
 const contentSecurityPolicy = [
   ["default-src", "'self'"],
   // 'unsafe-eval' sólo en desarrollo: lo necesita react-refresh.
-  ["script-src", "'self'", "'unsafe-inline'", ...(isDev ? ["'unsafe-eval'"] : []), ...ANALYTICS_ORIGINS, ...PAYPAL_ORIGINS],
+  ["script-src", "'self'", "'unsafe-inline'", ...(isDev ? ["'unsafe-eval'"] : []), ...ANALYTICS_SCRIPT_ORIGINS, ...PAYPAL_ORIGINS],
   ["style-src", "'self'", "'unsafe-inline'"],
   ["img-src", "'self'", "data:", "blob:", "https://lh3.googleusercontent.com", ...ANALYTICS_ORIGINS, ...PAYPAL_ORIGINS],
   ["font-src", "'self'", "data:"],


### PR DESCRIPTION
Add operational documentation and fix Content-Security-Policy for Google Analytics.

- Add docs/handover-2026-08-09.md (detailed incident handover, DB and infra changes).
- Add docs/instrucciones-proyecto.md (project onboarding and guidelines).
- Update CLAUDE.md with notes about GA4/CSP diagnostics.
- Update next.config.ts: split analytics script origins and add analytics.google.com + *.google-analytics.com to CSP connect/img allowlist so GA4 page_view requests are not blocked by CSP. Adds explanatory comments and preserves decision to not allowlist Google Signals endpoints.